### PR TITLE
Update .travis.yml to specify "trusty" dist for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 matrix:
  include:
   - os: linux
+    dist: trusty
   - os: osx
 
 language: go


### PR DESCRIPTION
Update .travis.yml to specify "trusty" dist for Linux as "docker" command seems to be borken on precise environment.