### PR TITLE
Relocate cloudprober/rtc package to targets/rtc/rtcservice.

### DIFF
--- a/targets/lameduck/lameduck.go
+++ b/targets/lameduck/lameduck.go
@@ -27,12 +27,12 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	"github.com/google/cloudprober/logger"
-	"github.com/google/cloudprober/rtc"
+	"github.com/google/cloudprober/targets/rtc/rtcservice"
 	"google.golang.org/api/runtimeconfig/v1beta1"
 )
 
 type lameDucksProvider struct {
-	rtc            rtc.Config
+	rtc            rtcservice.Config
 	opts           *Options
 	expirationTime time.Duration
 	l              *logger.Logger
@@ -153,7 +153,7 @@ func Init(optsProto *Options, l *logger.Logger) error {
 	cfg := optsProto.GetRuntimeconfigName()
 
 	onceLameDucksProvider.Do(func() {
-		rtc, err := rtc.New(proj, cfg)
+		rtc, err := rtcservice.New(proj, cfg)
 		if err != nil {
 			l.Errorf("targets: unable to build rtc config: %v", err)
 			return

--- a/targets/rtc/rtc_test.go
+++ b/targets/rtc/rtc_test.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/cloudprober/logger"
-	"github.com/google/cloudprober/rtc"
 	"github.com/google/cloudprober/targets/rtc/rtcreporter"
+	"github.com/google/cloudprober/targets/rtc/rtcservice"
 	"github.com/kylelemons/godebug/pretty"
 )
 
@@ -218,7 +218,7 @@ func TestRtctargsResolve(t *testing.T) {
 Nextrow:
 	for id, r := range rows {
 		// Setup targs
-		rtc := rtc.NewStub()
+		rtc := rtcservice.NewStub()
 		for _, v := range r.vars {
 			data, err := proto.Marshal(v.value)
 			if err != nil {
@@ -355,7 +355,7 @@ func TestRtctargsStale(t *testing.T) {
 Nextrow:
 	for id, r := range rows {
 		// Setup targs
-		rtc := rtc.NewStub()
+		rtc := rtcservice.NewStub()
 		for _, v := range r.vars {
 			data, err := proto.Marshal(v.value)
 			if err != nil {

--- a/targets/rtc/rtcreporter/rtcreporter.go
+++ b/targets/rtc/rtcreporter/rtcreporter.go
@@ -30,14 +30,14 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/cloudprober/logger"
-	"github.com/google/cloudprober/rtc"
+	"github.com/google/cloudprober/targets/rtc/rtcservice"
 )
 
 // Reporter provides the means and configuration for a cloudprober instance to
 // report its sysVars to a set of RTC configs.
 type Reporter struct {
 	pb         *RtcReportOptions
-	cfgs       []rtc.Config
+	cfgs       []rtcservice.Config
 	sysVars    map[string]string
 	reportVars []string
 	groups     []string
@@ -52,9 +52,9 @@ func New(pb *RtcReportOptions, sysVars map[string]string, l *logger.Logger) (*Re
 		return nil, errors.New("rtcserve.New: sysVars has no \"project\"")
 	}
 
-	var cfgs []rtc.Config
+	var cfgs []rtcservice.Config
 	for _, name := range pb.GetCfgs() {
-		c, err := rtc.New(proj, name)
+		c, err := rtcservice.New(proj, name)
 		if err != nil {
 			return nil, err
 		}
@@ -115,7 +115,7 @@ func (r *Reporter) mkTargetInfo() *RtcTargetInfo {
 	return pb
 }
 
-func (r *Reporter) report(c rtc.Config) error {
+func (r *Reporter) report(c rtcservice.Config) error {
 	pb := r.mkTargetInfo()
 	data, err := proto.Marshal(pb)
 	if err != nil {

--- a/targets/rtc/rtcreporter/rtcreporter_test.go
+++ b/targets/rtc/rtcreporter/rtcreporter_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/cloudprober/logger"
-	"github.com/google/cloudprober/rtc"
+	"github.com/google/cloudprober/targets/rtc/rtcservice"
 	"github.com/kylelemons/godebug/pretty"
 )
 
@@ -65,7 +65,7 @@ func TestReport(t *testing.T) {
 			"hostname":  "host1",
 			"public_ip": "1.1.1.1",
 		},
-		cfgs:       []rtc.Config{rtc.NewStub()},
+		cfgs:       []rtcservice.Config{rtcservice.NewStub()},
 		reportVars: []string{"public_ip"},
 		groups:     []string{"Group 1"},
 		l:          l,

--- a/targets/rtc/rtcservice/rtcservice.go
+++ b/targets/rtc/rtcservice/rtcservice.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package rtc provides utility functions for the cloudprober project used when
-// dealing with the Runtime Configurator API.
+// Package rtcservice provides utility functions for the cloudprober project
+// used when dealing with the Runtime Configurator API.
 // https://cloud.google.com/deployment-manager/runtime-configurator/reference/rest/
 // This API essentially provides a small key/val store for GCE
 // projects. Cloudprober uses this for things like maintaining a lameduck list,
@@ -24,11 +24,11 @@
 // as methods on the Config interface. This allows the behavior to be more
 // easily mocked for testing.
 //
-// rtc.Config is meant to represent a configuration or resource in the RTC sense
-// (see https://cloud.google.com/deployment-manager/runtime-configurator/). If
-// one needs to interact with multiple configurations, they will need multiple
+// rtcservice.Config is meant to represent a configuration or resource in the
+// RTC sense (see https://cloud.google.com/deployment-manager/runtime-configurator/).
+// If one needs to interact with multiple configurations, they will need multiple
 // instances of rtc.Config.
-package rtc
+package rtcservice
 
 import (
 	"encoding/base64"

--- a/targets/rtc/rtcservice/rtcservice_stub.go
+++ b/targets/rtc/rtcservice/rtcservice_stub.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rtc
+package rtcservice
 
 import (
 	"encoding/base64"

--- a/targets/rtc/rtcservice/rtcservice_test.go
+++ b/targets/rtc/rtcservice/rtcservice_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rtc
+package rtcservice
 
 import (
 	"fmt"


### PR DESCRIPTION
Relocate cloudprober/rtc package to targets/rtc/rtcservice. rtcservice is relevant only to targets so this improves code structure.

ORIGINAL_AUTHOR=Manu Garg <manugarg@gmail.com>
PiperOrigin-RevId: 164553980