### PR TITLE
Write logs to stderr and let Docker take care of these logs. With thi…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 #
 # Docker image built using this can executed in the following manner:
 #   docker run --net host -v $PWD/cloudprober.cfg:/etc/cloudprober.cfg \
-#                         -v /tmp:/tmp cloudprober/cloudprober
+#                         cloudprober/cloudprober
 FROM busybox
 ADD cloudprober /cloudprober
 COPY ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-CMD ["/cloudprober"]
+CMD ["/cloudprober", "--logtostderr"]


### PR DESCRIPTION
Write logs to stderr and let Docker take care of these logs. With this, we'll do away with the requirement of setting up /tmp volume. With this change logs will be accessed as docker logs <containername>.

ORIGINAL_AUTHOR=Manu Garg <manugarg@gmail.com>
PiperOrigin-RevId: 165622616