### PR TITLE
Fix the bug (#29) in external probe's server mode code.

### DIFF
--- a/probes/external/external.go
+++ b/probes/external/external.go
@@ -311,7 +311,7 @@ func (p *Probe) replyForProbe(ctx context.Context, requestID int32) (*serverutil
 func (p *Probe) sendRequest(requestID int32, labels map[string]string) error {
 	req := &serverutils.ProbeRequest{
 		RequestId: proto.Int32(requestID),
-		TimeLimit: proto.Int32(int32(p.timeout.Seconds()) * 1000),
+		TimeLimit: proto.Int32(int32(p.timeout.Nanoseconds() / 1000)),
 		Options:   []*serverutils.ProbeRequest_Option{},
 	}
 	for _, opt := range p.c.GetOptions() {


### PR DESCRIPTION
probes/external: Fix a bug where exeternal probe request's TimeLimit was getting set to 0 for sub-second timeouts. (Fixes #29)

ORIGINAL_AUTHOR=Manu Garg <manugarg@gmail.com>
PiperOrigin-RevId: 166118218