### PR TITLE
Fix external probe type's timeout

### DIFF
--- a/probes/external/external.go
+++ b/probes/external/external.go
@@ -311,7 +311,7 @@ func (p *Probe) replyForProbe(ctx context.Context, requestID int32) (*serverutil
 func (p *Probe) sendRequest(requestID int32, labels map[string]string) error {
 	req := &serverutils.ProbeRequest{
 		RequestId: proto.Int32(requestID),
-		TimeLimit: proto.Int32(int32(p.timeout.Nanoseconds() / 1000)),
+		TimeLimit: proto.Int32(int32(p.timeout / time.Millisecond)),
 		Options:   []*serverutils.ProbeRequest_Option{},
 	}
 	for _, opt := range p.c.GetOptions() {


### PR DESCRIPTION
In my last change (while trying to fix sub-seconds timeouts for external server probes), I wrongly converted probe request's timeout to microseconds instead of milliseconds which is how it's defined in the server.proto.

Future change: Make this field name more explicit (time_limit_msec) and make serverutils.Server provide a context to probe function.

ORIGINAL_AUTHOR=Manu Garg <manugarg@gmail.com>
PiperOrigin-RevId: 167728548