### PR TITLE
Make probe interface more flexible (and extensible).

### DIFF
--- a/probes/dns/cmd/dns.go
+++ b/probes/dns/cmd/dns.go
@@ -28,6 +28,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/cloudprober/metrics"
 	"github.com/google/cloudprober/probes/dns"
+	"github.com/google/cloudprober/probes/options"
 	"github.com/google/cloudprober/targets"
 )
 
@@ -54,12 +55,15 @@ func main() {
 		}
 	}
 
-	interval := *intervalF
-	timeout := *timeoutF
-	tgts := targets.StaticTargets(*targetsF)
+	opts := &options.Options{
+		Interval:  *intervalF,
+		Timeout:   *timeoutF,
+		Targets:   targets.StaticTargets(*targetsF),
+		ProbeConf: c,
+	}
 
 	dp := &dns.Probe{}
-	if err := dp.Init("dns_test", tgts, interval, timeout, nil, c); err != nil {
+	if err := dp.Init("dns_test", opts); err != nil {
 		glog.Exitf("Error in initializing probe %s from the config. Err: %v", "dns_test", err)
 	}
 	dataChan := make(chan *metrics.EventMetrics, 1000)

--- a/probes/external/cmd/external.go
+++ b/probes/external/cmd/external.go
@@ -28,6 +28,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/cloudprober/metrics"
 	"github.com/google/cloudprober/probes/external"
+	"github.com/google/cloudprober/probes/options"
 	"github.com/google/cloudprober/targets"
 )
 
@@ -57,13 +58,15 @@ func main() {
 		}
 	}
 
-	tgts := targets.StaticTargets(*targetsF)
-
-	interval := *intervalF
-	timeout := *timeoutF
+	opts := &options.Options{
+		Targets:   targets.StaticTargets(*targetsF),
+		Interval:  *intervalF,
+		Timeout:   *timeoutF,
+		ProbeConf: c,
+	}
 
 	ep := &external.Probe{}
-	if err := ep.Init("external_test", tgts, interval, timeout, nil, c); err != nil {
+	if err := ep.Init("external_test", opts); err != nil {
 		glog.Exitf("Error in initializing probe %s from the config. Err: %v", "external_test", err)
 	}
 	dataChan := make(chan *metrics.EventMetrics, 1000)

--- a/probes/external/external_test.go
+++ b/probes/external/external_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/cloudprober/logger"
 	"github.com/google/cloudprober/metrics"
 	"github.com/google/cloudprober/probes/external/serverutils"
+	"github.com/google/cloudprober/probes/options"
 	"github.com/google/cloudprober/targets"
 )
 
@@ -126,8 +127,10 @@ func TestProbeServer(t *testing.T) {
 	go startProbeServer(t, r1, w2)
 
 	p := &Probe{
-		tgts:       targets.StaticTargets("localhost"),
-		timeout:    5 * time.Second,
+		opts: &options.Options{
+			Targets: targets.StaticTargets("localhost"),
+			Timeout: 5 * time.Second,
+		},
 		l:          &logger.Logger{},
 		replyChan:  make(chan *serverutils.ProbeReply),
 		cmdRunning: true, // don't try to start the probe server
@@ -158,7 +161,7 @@ func TestProbeServer(t *testing.T) {
 	// Timeout
 	total++
 	// Reduce probe timeout to make this test pass quicker.
-	p.timeout = time.Second
+	p.opts.Timeout = time.Second
 	runAndVerifyProbe(t, p, "timeout", false, "", total, success)
 }
 
@@ -294,8 +297,10 @@ func TestSubstituteLabels(t *testing.T) {
 func TestSendRequest(t *testing.T) {
 	var buf bytes.Buffer
 	p := &Probe{
-		name:     "testprobe",
-		tgts:     targets.StaticTargets("localhost"),
+		name: "testprobe",
+		opts: &options.Options{
+			Targets: targets.StaticTargets("localhost"),
+		},
 		l:        &logger.Logger{},
 		cmdStdin: &buf,
 	}

--- a/probes/http/cmd/http.go
+++ b/probes/http/cmd/http.go
@@ -28,6 +28,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/cloudprober/metrics"
 	"github.com/google/cloudprober/probes/http"
+	"github.com/google/cloudprober/probes/options"
 	"github.com/google/cloudprober/targets"
 )
 
@@ -54,12 +55,15 @@ func main() {
 		}
 	}
 
-	interval := *intervalF
-	timeout := *timeoutF
-	tgts := targets.StaticTargets(*targetsF)
+	opts := &options.Options{
+		Interval:  *intervalF,
+		Timeout:   *timeoutF,
+		Targets:   targets.StaticTargets(*targetsF),
+		ProbeConf: c,
+	}
 
 	hp := &http.Probe{}
-	if err := hp.Init("http_test", tgts, interval, timeout, nil, c); err != nil {
+	if err := hp.Init("http_test", opts); err != nil {
 		glog.Exitf("Error in initializing probe %s from the config. Err: %v", "http_test", err)
 	}
 	dataChan := make(chan *metrics.EventMetrics, 1000)

--- a/probes/http/http_test.go
+++ b/probes/http/http_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/google/cloudprober/probes/options"
 	"github.com/google/cloudprober/probes/probeutils"
 	"github.com/google/cloudprober/targets"
 )
@@ -49,14 +50,17 @@ func (tt *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 func (tt *testTransport) CancelRequest(req *http.Request) {}
 
 func TestRun(t *testing.T) {
-	c := &ProbeConf{
-		RequestsPerProbe:        proto.Int32(1),
-		StatsExportIntervalMsec: proto.Int32(1000),
-	}
-
 	p := &Probe{}
-	tgts := targets.StaticTargets("test.com")
-	p.Init("http_test", tgts, 2*time.Second, time.Second, nil, c)
+	opts := &options.Options{
+		Targets:  targets.StaticTargets("test.com"),
+		Interval: 2 * time.Second,
+		Timeout:  time.Second,
+		ProbeConf: &ProbeConf{
+			RequestsPerProbe:        proto.Int32(1),
+			StatsExportIntervalMsec: proto.Int32(1000),
+		},
+	}
+	p.Init("http_test", opts)
 	p.client.Transport = newTestTransport()
 
 	resultsChan := make(chan probeutils.ProbeResult, len(p.targets))

--- a/probes/options/options.go
+++ b/probes/options/options.go
@@ -1,0 +1,33 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package options provides a shared interface to common probe options.
+*/
+package options
+
+import (
+	"time"
+
+	"github.com/google/cloudprober/logger"
+	"github.com/google/cloudprober/targets"
+)
+
+// Options encapsulates common probe options.
+type Options struct {
+	Targets           targets.Targets
+	Interval, Timeout time.Duration
+	Logger            *logger.Logger
+	ProbeConf         interface{} // Probe-type specific config
+}

--- a/probes/ping/cmd/ping.go
+++ b/probes/ping/cmd/ping.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/cloudprober/metrics"
+	"github.com/google/cloudprober/probes/options"
 	"github.com/google/cloudprober/probes/ping"
 	"github.com/google/cloudprober/targets"
 )
@@ -38,8 +39,6 @@ var (
 func main() {
 	flag.Parse()
 
-	tgts := targets.StaticTargets(*targetsF)
-
 	probeConfig := &ping.ProbeConf{}
 	if *config != "" {
 		b, err := ioutil.ReadFile(*config)
@@ -50,8 +49,15 @@ func main() {
 			glog.Exitf("error while parsing config: %v", err)
 		}
 	}
+
+	opts := &options.Options{
+		Targets:   targets.StaticTargets(*targetsF),
+		Interval:  2 * time.Second,
+		Timeout:   time.Second,
+		ProbeConf: probeConfig,
+	}
 	p := &ping.Probe{}
-	if err := p.Init("ping", tgts, 2*time.Second, time.Second, nil, probeConfig); err != nil {
+	if err := p.Init("ping", opts); err != nil {
 		glog.Exitf("error initializing ping probe from config: %v", err)
 	}
 

--- a/probes/ping/ping_test.go
+++ b/probes/ping/ping_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/cloudprober/logger"
+	"github.com/google/cloudprober/probes/options"
 	"github.com/google/cloudprober/targets"
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
@@ -162,13 +163,14 @@ func sendAndCheckPackets(p *Probe, t *testing.T) {
 }
 
 func newProbe(c *ProbeConf, t []string) (*Probe, error) {
-	tgts := targets.StaticTargets(strings.Join(t, ","))
 	p := &Probe{
-		name:        "ping_test",
-		c:           c,
-		interval:    2 * time.Second,
-		timeout:     time.Second,
-		tgts:        tgts,
+		name: "ping_test",
+		c:    c,
+		opts: &options.Options{
+			Targets:  targets.StaticTargets(strings.Join(t, ",")),
+			Interval: 2 * time.Second,
+			Timeout:  time.Second,
+		},
 		ipVer:       int(c.GetIpVersion()),
 		l:           &logger.Logger{},
 		sent:        make(map[string]int64),
@@ -178,7 +180,7 @@ func newProbe(c *ProbeConf, t []string) (*Probe, error) {
 		target2addr: make(map[string]net.Addr),
 	}
 
-	p.targets = p.tgts.List()
+	p.targets = p.opts.Targets.List()
 	return p, p.setSourceFromConfig()
 }
 

--- a/probes/udp/cmd/udp.go
+++ b/probes/udp/cmd/udp.go
@@ -27,6 +27,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/cloudprober/metrics"
+	"github.com/google/cloudprober/probes/options"
 	"github.com/google/cloudprober/probes/udp"
 	"github.com/google/cloudprober/targets"
 )
@@ -54,12 +55,15 @@ func main() {
 		}
 	}
 
-	interval := *intervalF
-	timeout := *timeoutF
-	tgts := targets.StaticTargets(*targetsF)
+	opts := &options.Options{
+		Targets:   targets.StaticTargets(*targetsF),
+		Interval:  *intervalF,
+		Timeout:   *timeoutF,
+		ProbeConf: c,
+	}
 
 	up := &udp.Probe{}
-	if err := up.Init("udp_test", tgts, interval, timeout, nil, c); err != nil {
+	if err := up.Init("udp_test", opts); err != nil {
 		glog.Exitf("Error in initializing probe %s from the config. Err: %v", "udp_test", err)
 	}
 	dataChan := make(chan *metrics.EventMetrics, 1000)


### PR DESCRIPTION
Make probe interface more flexible (and extensible) by encapsulating common probe options in a struct. We'll pass this struct at the time of probe initialization rather than passing all individual options separately. This will allow us to extend options without changing the API.

ORIGINAL_AUTHOR=Manu Garg <manugarg@gmail.com>
PiperOrigin-RevId: 175629673