### PR TITLE
Add a few Go runtime stats.

### DIFF
--- a/sysvars/runtime.go
+++ b/sysvars/runtime.go
@@ -1,0 +1,67 @@
+package sysvars
+
+import (
+	"runtime"
+	"time"
+
+	"github.com/google/cloudprober/logger"
+	"github.com/google/cloudprober/metrics"
+	"google3/third_party/golang/go_sys/unix/unix"
+)
+
+func runtimeVars(dataChan chan *metrics.EventMetrics, l *logger.Logger) {
+	m := &runtime.MemStats{}
+	runtime.ReadMemStats(m)
+	ts := time.Now()
+	counterRuntimeVars(dataChan, ts, m, l)
+	gaugeRuntimeVars(dataChan, ts, m, l)
+}
+
+// counterRuntimeVars exports counter runtime stats, stats that grow through
+// the lifetime of the process. These stats are exported as CUMULATIVE
+// EventMetrics.
+func counterRuntimeVars(dataChan chan *metrics.EventMetrics, ts time.Time, m *runtime.MemStats, l *logger.Logger) {
+	em := metrics.NewEventMetrics(ts).
+		AddLabel("ptype", "sysvars").
+		AddLabel("probe", "sysvars")
+
+	// Time since this module started.
+	timeSince := time.Since(startTime).Seconds()
+	em.AddMetric("uptime_msec", metrics.NewFloat(timeSince*1000))
+	// TODO: Deprecate "uptime" in favor of "uptime_msec".
+	em.AddMetric("uptime", metrics.NewInt(int64(timeSince)))
+
+	// GC memory stats
+	em.AddMetric("gc_time_msec", metrics.NewFloat(float64(m.PauseTotalNs)/1e6))
+	em.AddMetric("mallocs", metrics.NewInt(int64(m.Mallocs)))
+	em.AddMetric("frees", metrics.NewInt(int64(m.Frees)))
+
+	// CPU usage
+	var timeSpec unix.Timespec
+	if err := unix.ClockGettime(unix.CLOCK_PROCESS_CPUTIME_ID, &timeSpec); err != nil {
+		l.Warningf("Error while trying to get CPU usage: %v", err)
+	} else {
+		em.AddMetric("cpu_usage_msec", metrics.NewFloat(float64(timeSpec.Nano())/1e6))
+	}
+
+	dataChan <- em
+	l.Info(em.String())
+}
+
+// gaugeRuntimeVars exports gauge runtime stats, stats that represent the
+// current state and may go up or down. These stats are exported as GAUGE
+// EventMetrics.
+func gaugeRuntimeVars(dataChan chan *metrics.EventMetrics, ts time.Time, m *runtime.MemStats, l *logger.Logger) {
+	em := metrics.NewEventMetrics(ts).
+		AddLabel("ptype", "sysvars").
+		AddLabel("probe", "sysvars")
+	em.Kind = metrics.GAUGE
+
+	// Number of goroutines
+	em.AddMetric("goroutines", metrics.NewInt(int64(runtime.NumGoroutine())))
+	// Overall memory being used by the Go runtime (in bytes).
+	em.AddMetric("mem_stats_sys_bytes", metrics.NewInt(int64(m.Sys)))
+
+	dataChan <- em
+	l.Info(em.String())
+}

--- a/sysvars/runtime.go
+++ b/sysvars/runtime.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/google/cloudprober/logger"
 	"github.com/google/cloudprober/metrics"
-	"google3/third_party/golang/go_sys/unix/unix"
 )
 
 func runtimeVars(dataChan chan *metrics.EventMetrics, l *logger.Logger) {
 	m := &runtime.MemStats{}
 	runtime.ReadMemStats(m)
 	ts := time.Now()
+	osRuntimeVars(dataChan, l)
 	counterRuntimeVars(dataChan, ts, m, l)
 	gaugeRuntimeVars(dataChan, ts, m, l)
 }
@@ -35,14 +35,6 @@ func counterRuntimeVars(dataChan chan *metrics.EventMetrics, ts time.Time, m *ru
 	em.AddMetric("gc_time_msec", metrics.NewFloat(float64(m.PauseTotalNs)/1e6))
 	em.AddMetric("mallocs", metrics.NewInt(int64(m.Mallocs)))
 	em.AddMetric("frees", metrics.NewInt(int64(m.Frees)))
-
-	// CPU usage
-	var timeSpec unix.Timespec
-	if err := unix.ClockGettime(unix.CLOCK_PROCESS_CPUTIME_ID, &timeSpec); err != nil {
-		l.Warningf("Error while trying to get CPU usage: %v", err)
-	} else {
-		em.AddMetric("cpu_usage_msec", metrics.NewFloat(float64(timeSpec.Nano())/1e6))
-	}
 
 	dataChan <- em
 	l.Info(em.String())

--- a/sysvars/runtime_linux.go
+++ b/sysvars/runtime_linux.go
@@ -1,0 +1,28 @@
+//+build linux
+
+package sysvars
+
+import (
+	"time"
+
+	"github.com/google/cloudprober/logger"
+	"github.com/google/cloudprober/metrics"
+	"golang.org/x/sys/unix"
+)
+
+func osRuntimeVars(dataChan chan *metrics.EventMetrics, l *logger.Logger) {
+	em := metrics.NewEventMetrics(time.Now()).
+		AddLabel("ptype", "sysvars").
+		AddLabel("probe", "sysvars")
+
+	// CPU usage
+	var timeSpec unix.Timespec
+	if err := unix.ClockGettime(unix.CLOCK_PROCESS_CPUTIME_ID, &timeSpec); err != nil {
+		l.Warningf("Error while trying to get CPU usage: %v", err)
+	} else {
+		em.AddMetric("cpu_usage_msec", metrics.NewFloat(float64(timeSpec.Nano())/1e6))
+	}
+
+	dataChan <- em
+	l.Info(em.String())
+}

--- a/sysvars/runtime_nonlinux.go
+++ b/sysvars/runtime_nonlinux.go
@@ -1,0 +1,13 @@
+//+build !linux
+
+package sysvars
+
+import (
+	"github.com/google/cloudprober/logger"
+	"github.com/google/cloudprober/metrics"
+)
+
+// osRuntimeVars doesn't anything for the non-Linux systems yet. We have it
+// here to make sysvars package compilation work on non-Linux systems.
+func osRuntimeVars(dataChan chan *metrics.EventMetrics, l *logger.Logger) {
+}

--- a/sysvars/runtime_test.go
+++ b/sysvars/runtime_test.go
@@ -1,0 +1,60 @@
+package sysvars
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/google/cloudprober/logger"
+	"github.com/google/cloudprober/metrics"
+)
+
+func TestCounterRuntimeVars(t *testing.T) {
+	dataChan := make(chan *metrics.EventMetrics, 1)
+	l := &logger.Logger{}
+	m := &runtime.MemStats{}
+	runtime.ReadMemStats(m)
+	ts := time.Now()
+
+	counterRuntimeVars(dataChan, ts, m, l)
+	em := <-dataChan
+
+	if em.Timestamp != ts {
+		t.Errorf("em.Timestamp=%v, want=%v", em.Timestamp, ts)
+	}
+
+	if em.Kind != metrics.CUMULATIVE {
+		t.Errorf("Metrics kind is not cumulative.")
+	}
+
+	for _, name := range []string{"uptime", "uptime_msec", "gc_time_msec", "mallocs", "frees", "cpu_usage_msec"} {
+		if em.Metric(name) == nil {
+			t.Errorf("Expected metric \"%s\" not defined in EventMetrics: %s", name, em.String())
+		}
+	}
+}
+
+func TestGaugeRuntimeVars(t *testing.T) {
+	dataChan := make(chan *metrics.EventMetrics, 1)
+	l := &logger.Logger{}
+	m := &runtime.MemStats{}
+	runtime.ReadMemStats(m)
+	ts := time.Now()
+
+	gaugeRuntimeVars(dataChan, ts, m, l)
+	em := <-dataChan
+
+	if em.Timestamp != ts {
+		t.Errorf("em.Timestamp=%v, want=%v", em.Timestamp, ts)
+	}
+
+	if em.Kind != metrics.GAUGE {
+		t.Errorf("Metrics kind is not gauge.")
+	}
+
+	for _, name := range []string{"goroutines", "mem_stats_sys_bytes"} {
+		if em.Metric(name) == nil {
+			t.Errorf("Expected metric \"%s\" not defined in EventMetrics: %s", name, em.String())
+		}
+	}
+}

--- a/sysvars/runtime_test.go
+++ b/sysvars/runtime_test.go
@@ -27,7 +27,7 @@ func TestCounterRuntimeVars(t *testing.T) {
 		t.Errorf("Metrics kind is not cumulative.")
 	}
 
-	for _, name := range []string{"uptime", "uptime_msec", "gc_time_msec", "mallocs", "frees", "cpu_usage_msec"} {
+	for _, name := range []string{"uptime", "uptime_msec", "gc_time_msec", "mallocs", "frees"} {
 		if em.Metric(name) == nil {
 			t.Errorf("Expected metric \"%s\" not defined in EventMetrics: %s", name, em.String())
 		}

--- a/sysvars/sysvars.go
+++ b/sysvars/sysvars.go
@@ -137,12 +137,9 @@ func Start(ctx context.Context, dataChan chan *metrics.EventMetrics, interval ti
 		for _, k := range varsKeys {
 			em.AddMetric(k, metrics.NewString(vars[k]))
 		}
-
-		// Uptime is since this module started.
-		timeSince := time.Since(startTime).Seconds()
-		em.AddMetric("uptime", metrics.NewInt(int64(timeSince)))
-
 		dataChan <- em
 		l.Info(em.String())
+
+		runtimeVars(dataChan, l)
 	}
 }


### PR DESCRIPTION
Add a few Go runtime stats to help with debugging cloudprober performance/health.

cloudprober 1513308467341380164 1513308517 labels=ptype=sysvars,probe=sysvars uptime_msec=50001.34 gc_time_msec=1827920 mallocs=80363 frees=39703 cpu_usage=690762494
cloudprober 1513308467341380185 1513308567 labels=ptype=sysvars,probe=sysvars goroutines=161 mem_stats_sys_bytes=17836280

ORIGINAL_AUTHOR=Manu Garg <manugarg@gmail.com>
PiperOrigin-RevId: 179240256