### PR TITLE
Refactor lameduck package

### DIFF
--- a/probes/probes.go
+++ b/probes/probes.go
@@ -83,7 +83,7 @@ func Init(probeProtobufs []*ProbeDef, globalTargetsOpts *targets.GlobalTargetsOp
 	}
 	if globalTargetsOpts != nil {
 		if globalTargetsOpts.GetLameDuckOptions() != nil && metadata.OnGCE() {
-			if err := lameduck.Init(globalTargetsOpts.GetLameDuckOptions(), globalTargetsLogger); err != nil {
+			if err := lameduck.InitDefaultLister(globalTargetsOpts.GetLameDuckOptions(), nil, globalTargetsLogger); err != nil {
 				glog.Exitf("Error in initializing lameduck module. Err: %v", err)
 			}
 		}

--- a/targets/lameduck/lameduck_test.go
+++ b/targets/lameduck/lameduck_test.go
@@ -1,0 +1,63 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// TODO: Add more tests after a bit of refactoring.
+
+package lameduck
+
+import (
+	"reflect"
+	"testing"
+)
+
+type mockLDLister struct {
+	list []string
+}
+
+func (mldl *mockLDLister) List() ([]string, error) {
+	return mldl.list, nil
+}
+
+func TestDefaultLister(t *testing.T) {
+	list1 := []string{"list1"}
+
+	// Initialize default lister with the given lister
+	InitDefaultLister(nil, &mockLDLister{list1}, nil)
+	lister, err := GetDefaultLister()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotList, err := lister.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(gotList, list1) {
+		t.Errorf("Default lister retured: %v, expected: %v", gotList, list1)
+	}
+
+	list2 := []string{"list2"}
+	// Initialize default lister with the given lister. This time it should have
+	// no impact as default lister is already initialized.
+	InitDefaultLister(nil, &mockLDLister{list2}, nil)
+	lister, err = GetDefaultLister()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotList, err = lister.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(gotList, list1) {
+		t.Errorf("Default lister retured: %v, expected: %v", gotList, list1)
+	}
+}


### PR DESCRIPTION
Refactor lameduck package to make it more intuitive and testing friendly.

= Define a new interface called Lister that implements only List() method. Use this interface for global singleton rather than the whole lameduck.Service. We need to share only Lister among lameduck users.
= Remove package level functions as they create more confusion than convenience. To avoid passing around global lister, provide a GetDefaultLister() method.
= Subsequently change targets.Targets struct to include a ldLister field that will be initialized to lameduck.GetDefaultLister() at the time of targets creation.
= Also remove the IsLameducking() method. It's not providing much value.

ORIGINAL_AUTHOR=Manu Garg <manugarg@gmail.com>
PiperOrigin-RevId: 181194094