### PR TITLE
Metrics performance optimization.

### DIFF
--- a/metrics/eventmetrics_test.go
+++ b/metrics/eventmetrics_test.go
@@ -104,5 +104,21 @@ func TestEventMetricsUpdate(t *testing.T) {
 	})
 
 	// Log metrics in string format
-	t.Log(m.String())
+	// t.Log(m.String())
+
+	expectedString := fmt.Sprintf("%d labels=ptype=http sent=62 rcvd=52 rtt=520200 resp-code=map:code,200:44,204:8", m.Timestamp.Unix())
+	s := m.String()
+	if s != expectedString {
+		t.Errorf("em.String()=%s, want=%s", s, expectedString)
+	}
+}
+
+func BenchmarkEventMetricsStringer(b *testing.B) {
+	em := newEventMetrics(32, 22, 220100, map[string]int64{
+		"200": 22,
+	})
+	// run the em.String() function b.N times
+	for n := 0; n < b.N; n++ {
+		em.String()
+	}
 }


### PR DESCRIPTION
Optimize EventMetrics stringer for memory allocation. This function is called too many times and based on profiling is responsible for significant number of object allocations:
http://gpaste/6575839500042240

Benchmark results show significant improvement in time spent per op, 1.9 (1.4 if run for 20s) vs 4.8.
Before this change:
BenchmarkEventMetricsStringer-33    	  300000	      4830 ns/op
After this change:
BenchmarkEventMetricsStringer-16    	 1000000	      1928 ns/op

ORIGINAL_AUTHOR=Manu Garg <manugarg@gmail.com>
PiperOrigin-RevId: 186687177