### PR TITLE
float: Don't cast a float value as an int

### DIFF
--- a/metrics/float.go
+++ b/metrics/float.go
@@ -16,7 +16,7 @@ package metrics
 
 import (
 	"errors"
-	"strconv"
+	"fmt"
 )
 
 // Float implements NumValue with float64 storage. Note that Float is not concurrency
@@ -89,8 +89,5 @@ func (f *Float) String() string {
 	if f.Str != nil {
 		return f.Str(f.Float64())
 	}
-	// Truncate the float to 3-digit precision.
-	// Example: 3.33333333333 -> 3.333
-	ff := float64(int(f.f*1000)) / 1000
-	return strconv.FormatFloat(ff, 'f', -1, 64)
+	return fmt.Sprintf("%f", f.f)
 }


### PR DESCRIPTION
On ARM system, the int type is defaulting to the size of int32 and can
easily be overrun.

Instead of casting as an int to set the precision of the value, use
fmt.Sprintf to return the float as a string with full precision.

Fixes #117 