### PR TITLE
float: Don't cast a float value as an int

### DIFF
--- a/metrics/float.go
+++ b/metrics/float.go
@@ -89,8 +89,5 @@ func (f *Float) String() string {
 	if f.Str != nil {
 		return f.Str(f.Float64())
 	}
-	// Truncate the float to 3-digit precision.
-	// Example: 3.33333333333 -> 3.333
-	ff := float64(int(f.f*1000)) / 1000
-	return strconv.FormatFloat(ff, 'f', -1, 64)
+	return strconv.FormatFloat(f.f, 'f', 3, 64)
 }


### PR DESCRIPTION
On ARM system, the int type is defaulting to the size of int32 and can easily be overrun. As discussed in #117, we can skip trimming the trailing zeros. It's not adding much value and making the code obscure.

PiperOrigin-RevId: 193150323