### PR TITLE
Allow the server listening address to be changed

### DIFF
--- a/cloudprober.go
+++ b/cloudprober.go
@@ -50,9 +50,11 @@ const (
 	sysvarsModuleName = "sysvars"
 )
 
-// Constants defining the default server port.
+// Constants defining the default server host and port.
 const (
+	DefaultServerHost = ""
 	DefaultServerPort = 9313
+	ServerHostEnvVar  = "CLOUDPROBER_HOST"
 	ServerPortEnvVar  = "CLOUDPROBER_PORT"
 )
 
@@ -74,6 +76,16 @@ type Prober struct {
 }
 
 func (pr *Prober) initDefaultServer() error {
+	serverHost := pr.c.GetHost()
+	if serverHost == "" {
+		serverHost = DefaultServerHost
+		// If ServerHostEnvVar is defined, it will override the default
+		// server host.
+		if host := os.Getenv(ServerHostEnvVar); host != "" {
+			serverHost = host
+		}
+	}
+
 	serverPort := int(pr.c.GetPort())
 	if serverPort == 0 {
 		serverPort = DefaultServerPort
@@ -89,7 +101,7 @@ func (pr *Prober) initDefaultServer() error {
 		}
 	}
 
-	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", serverPort))
+	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", serverHost, serverPort))
 	if err != nil {
 		return fmt.Errorf("error while creating listener for default HTTP server. Err: %v", err)
 	}

--- a/config/proto/config.pb.go
+++ b/config/proto/config.pb.go
@@ -46,6 +46,11 @@ type ProberConfig struct {
 	// exporter (URL /metrics). Default port is 9313. If not specified in the
 	// config, default port can be overridden by the environment variable
 	// CLOUDPROBER_PORT.
+	Host *string `protobuf:"bytes,101,opt,name=host" json:"host,omitempty"`
+	// Port for the default HTTP server. This port is also used for prometheus
+	// exporter (URL /metrics). Default port is 9313. If not specified in the
+	// config, default port can be overridden by the environment variable
+	// CLOUDPROBER_PORT.
 	Port *int32 `protobuf:"varint,96,opt,name=port" json:"port,omitempty"`
 	// How often to export system variables. To learn more about system variables:
 	// http://godoc.org/github.com/google/cloudprober/sysvars.
@@ -122,6 +127,13 @@ func (m *ProberConfig) GetRdsServer() *proto4.ServerConf {
 		return m.RdsServer
 	}
 	return nil
+}
+
+func (m *ProberConfig) GetHost() string {
+	if m != nil && m.Host != nil {
+		return *m.Host
+	}
+	return ""
 }
 
 func (m *ProberConfig) GetPort() int32 {

--- a/config/proto/config.proto
+++ b/config/proto/config.proto
@@ -57,4 +57,9 @@ message ProberConfig {
   // Global targets options. Per-probe options are specified within the probe
   // stanza.
   optional targets.GlobalTargetsOptions global_targets_options = 100;
+
+  // Host for the default HTTP server. Default listens on all addresses. If not
+  // specified in the config, default port can be overridden by the environment
+  // variable CLOUDPROBER_HOST.
+  optional string host = 101;
 }

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -31,8 +31,9 @@ docker run --net host cloudprober/cloudprober
 Without any config, cloudprober will run only the "sysvars" module (no probes)
 and write metrics to stdout in cloudprober's line protocol format (to be
 documented). It will also start a [Prometheus](http://prometheus.io) exporter
-at: http://localhost:9313 (you can change the default port through the
-environment variable _CLOUDPROBER_PORT_).
+at: http://localhost:9313 listening on all addresses. (you can change the default
+port through the environment varible _CLOUDPROBER_PORT_ and the default listening
+address through the environment variable _CLOUDPROBER_HOST_).
 
 Since sysvars variables are not very interesting themselves, lets add a simple
 config that probes Google's homepage:


### PR DESCRIPTION
It may be desired to change the listening address of the http server to
set it for a specific address or interface. Check for the environment
variable CLOUDPROBER_HOST and listen on that hostname/address if given.
If not available, default to the existing setting of listening on all
addresses.