### PR TITLE
rtcservice: Don't try to list during initialization.

### DIFF
--- a/targets/rtc/rtcservice/rtcservice.go
+++ b/targets/rtc/rtcservice/rtcservice.go
@@ -85,13 +85,8 @@ func New(proj string, cfg string, c *http.Client) (Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	s := &impl{svc, proj, cfg}
-	// Checks that proj and cfg are valid by trying to list variables.
-	_, err = s.List()
-	if err != nil {
-		return nil, err
-	}
-	return s, nil
+	// TODO: Consider checking for the configuration errors before returning.
+	return &impl{svc, proj, cfg}, nil
 }
 
 // This helper function is used to actually connect to an RTC client.


### PR DESCRIPTION
List can fail for many reasons, which don't have anything to do with the configuration problems. We should either examine the List() error to find out the actual cause of failure or just not List() during init(). I am going with the latter. I have added a TODO to explore the former.

PiperOrigin-RevId: 202541985