### PR TITLE
Add "mkMap" function (macro) to cloudprober config.

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,13 +34,44 @@ probe {
 		"region": "testRegion",
 	})
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if len(c.GetProbe()) != 1 {
 		t.Errorf("Didn't get correct number of probes. Got: %d, Expected: %d", len(c.GetProbe()), 1)
 	}
 	probeName := c.GetProbe()[0].GetName()
 	expectedName := "vm-to-google-02-testRegion"
+	if probeName != expectedName {
+		t.Errorf("Incorrect probe name. Got: %s, Expected: %s", probeName, expectedName)
+	}
+}
+
+func TestParseMap(t *testing.T) {
+	testConfig := `
+{{define "probeTmpl"}}
+probe {
+  type: {{.typ}}
+  name: "{{.name}}"
+  targets {
+    host_names: "www.google.com"
+  }
+  ping_probe {
+    use_datagram_socket: true
+  }
+}
+{{end}}
+
+{{template "probeTmpl" mkMap "typ" "PING" "name" "ping_google"}}
+`
+	c, err := Parse(testConfig, map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(c.GetProbe()) != 1 {
+		t.Errorf("Didn't get correct number of probes. Got: %d, Expected: %d", len(c.GetProbe()), 1)
+	}
+	probeName := c.GetProbe()[0].GetName()
+	expectedName := "ping_google"
 	if probeName != expectedName {
 		t.Errorf("Incorrect probe name. Got: %s, Expected: %s", probeName, expectedName)
 	}


### PR DESCRIPTION
mkMap build a map from the provided arguments. It's useful as Go templates take only one argument. With this function, we can create a map of multiple values and pass it to a template.

PiperOrigin-RevId: 202559282