### PR TITLE
Fix config.proto url in getting started doc

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -56,7 +56,7 @@ This config adds an HTTP probe that accesses the homepage of the target
 "www.google.com" every 5s with a timout of 1s. Cloudprober configuration is
 specified in the text protobuf format, with config schema described by the
 proto file: [config.proto
-](https://github.com/google/cloudprober/blob/master/config/config.proto).
+](https://github.com/google/cloudprober/blob/master/config/proto/config.proto).
 
 Assuming that you saved this file at /tmp/cloudprober.cfg (following the
 command above), you can have cloudprober use this config file using the following command line:


### PR DESCRIPTION
Link is broken in documentation, because file was moved in `proto/` directory.