### PR TITLE
Surfacers: Infer type if not specified.

### DIFF
--- a/surfacers/surfacers_test.go
+++ b/surfacers/surfacers_test.go
@@ -17,6 +17,9 @@ package surfacers
 import (
 	"testing"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/google/cloudprober/surfacers/file"
+	fileconfigpb "github.com/google/cloudprober/surfacers/file/proto"
 	surfacerpb "github.com/google/cloudprober/surfacers/proto"
 )
 
@@ -36,6 +39,28 @@ func TestEmptyConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(s) != 0 {
+		t.Errorf("Got surfacers for zero config: %v", s)
+	}
+}
+
+func TestInferType(t *testing.T) {
+	s, err := Init([]*surfacerpb.SurfacerDef{
+		{
+			Surfacer: &surfacerpb.SurfacerDef_FileSurfacer{
+				&fileconfigpb.SurfacerConf{
+					FilePath: proto.String("/tmp/x"),
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(s) != 1 {
+		t.Errorf("len(s)=%d, expected=1", len(s))
+	}
+	if _, ok := s[0].Surfacer.(*file.FileSurfacer); !ok {
 		t.Errorf("Got surfacers for zero config: %v", s)
 	}
 }


### PR DESCRIPTION
Surfacer type is currently defined as optional. For that to work correctly, we should infer type if type is not specified but surfacer has other info.

For example, following should work:

surfacer {
  file_surfacer {
    file_path: "/tmp/metrics"
  }
}

Currently it results in silent discard of this surfacer.

PiperOrigin-RevId: 224078602