### PR TITLE
Restructure the status template to improve readability.

### DIFF
--- a/probes/probes_status_tmpl.go
+++ b/probes/probes_status_tmpl.go
@@ -1,0 +1,55 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package probes
+
+import "html/template"
+
+// StatusTmpl variable stores the HTML template suitable to generate the
+// probes' status for cloudprober's /status page. It expects an array of
+// ProbeInfo objects as input.
+var StatusTmpl = template.Must(template.New("statusTmpl").Parse(`
+<table class="status-list">
+  <tr>
+    <th>Name</th>
+    <th>Type</th>
+    <th>Interval</th>
+    <th>Timeout</th>
+    <th>Targets</th>
+    <th>Probe Conf</th>
+    <th>Latency Unit</th>
+    <th>Latency Distribution Lower Bounds (if configured) </th>
+  </tr>
+  {{ range . }}
+  <tr>
+    <td>{{.Name}}</td>
+    <td>{{.Type}}</td>
+    <td>{{.Interval}}</td>
+    <td>{{.Timeout}}</td>
+    <td><pre>{{.TargetsDesc}}</pre></td>
+
+    <td>
+    {{if .ProbeConf}}
+      <pre>{{.ProbeConf}}</pre>
+    {{else}}
+      default
+    {{end}}
+    </td>
+
+    <td>{{.LatencyUnit}}</td>
+    <td><pre>{{.LatencyDistLB}}</pre></td>
+  </tr>
+  {{ end }}
+</table>
+`))

--- a/servers/servers.go
+++ b/servers/servers.go
@@ -20,6 +20,7 @@ package servers
 import (
 	"context"
 	"fmt"
+	"html/template"
 
 	"github.com/google/cloudprober/logger"
 	"github.com/google/cloudprober/metrics"
@@ -32,6 +33,32 @@ import (
 const (
 	logsNamePrefix = "cloudprober"
 )
+
+// StatusTmpl variable stores the HTML template suitable to generate the
+// servers' status for cloudprober's /status page. It expects an array of
+// ServerInfo objects as input.
+var StatusTmpl = template.Must(template.New("statusTmpl").Parse(`
+<table class="status-list">
+  <tr>
+    <th>Type</th>
+    <th>Name</th>
+    <th>Conf</th>
+  </tr>
+  {{ range . }}
+  <tr>
+    <td>{{.Type}}</td>
+    <td>{{.Name}}</td>
+    <td>
+    {{if .Conf}}
+      <pre>{{.Conf}}</pre>
+    {{else}}
+      default
+    {{end}}
+    </td>
+  </tr>
+  {{ end }}
+</table>
+`))
 
 func newLogger(ctx context.Context, logName string) (*logger.Logger, error) {
 	return logger.New(ctx, logsNamePrefix+"."+logName)

--- a/surfacers/surfacers.go
+++ b/surfacers/surfacers.go
@@ -26,6 +26,7 @@ package surfacers
 import (
 	"context"
 	"fmt"
+	"html/template"
 	"strings"
 	"sync"
 
@@ -44,6 +45,32 @@ var (
 	userDefinedSurfacers   = make(map[string]Surfacer)
 	userDefinedSurfacersMu sync.Mutex
 )
+
+// StatusTmpl variable stores the HTML template suitable to generate the
+// surfacers' status for cloudprober's /status page. It expects an array of
+// SurfacerInfo objects as input.
+var StatusTmpl = template.Must(template.New("statusTmpl").Parse(`
+<table class="status-list">
+  <tr>
+    <th>Type</th>
+    <th>Name</th>
+    <th>Conf</th>
+  </tr>
+  {{ range . }}
+  <tr>
+    <td>{{.Type}}</td>
+    <td>{{.Name}}</td>
+    <td>
+    {{if .Conf}}
+      <pre>{{.Conf}}</pre>
+    {{else}}
+      default
+    {{end}}
+    </td>
+  </tr>
+  {{ end }}
+</table>
+`))
 
 // Default surfacers. These surfacers are enabled if no surfacer is defined.
 var defaultSurfacers = []*surfacerpb.SurfacerDef{

--- a/web/status_tmpl.go
+++ b/web/status_tmpl.go
@@ -1,0 +1,32 @@
+package web
+
+var statusTmpl = `
+<html>
+
+<style type="text/css">
+table.status-list {
+  border-collapse: collapse;
+  border-spacing: 0;
+	margin-bottom: 40px;
+	font-family: monospace;
+}
+table.status-list td,th {
+  border: 1px solid gray;
+  padding: 0.25em 0.5em;
+	max-width: 200px;
+}
+pre {
+    white-space: pre-wrap;
+		word-wrap: break-word;
+}
+</style>
+
+<h3>Probes:</h3>
+{{.ProbesStatus}}
+
+<h3>Surfacers:</h3>
+{{.SurfacersStatus}}
+
+<h3>Servers:</h3>
+{{.ServersStatus}}
+`


### PR DESCRIPTION
= Consolidate the main status template code in a single file - status_tmpl.go. This file will define the HTML structure of the page.
= Move servers and surfacers status HTML handling to their respective packages.

PiperOrigin-RevId: 224552514