### PR TITLE
Use generic logging if the logger.Logger is nil.

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -153,7 +153,7 @@ func (l *Logger) log(severity logging.Severity, payload interface{}) {
 		textPayload = textPayload[:MaxLogEntrySize-truncateMsgLen] + truncateMsg
 		payload = textPayload
 	}
-	if l.logc == nil {
+	if l == nil || l.logc == nil {
 		genericLog(severity, textPayload)
 		return
 	}


### PR DESCRIPTION
Generic logging doesn't need any extra state and thus we can handle the case of a nil receiver gracefully.

PiperOrigin-RevId: 224564914