### PR TITLE
Further improvements to the status page (/status).

### DIFF
--- a/probes/probes.go
+++ b/probes/probes.go
@@ -202,7 +202,9 @@ func Init(probeProtobufs []*configpb.ProbeDef, globalTargetsOpts *targetspb.Glob
 
 		// If probeConf supports String() function, use it for status page.
 		probeConfStr := ""
-		if stringer, ok := probeConf.(fmt.Stringer); ok {
+		if msg, ok := probeConf.(proto.Message); ok {
+			probeConfStr = proto.MarshalTextString(msg)
+		} else if stringer, ok := probeConf.(fmt.Stringer); ok {
 			probeConfStr = stringer.String()
 		}
 

--- a/probes/probes_status_tmpl.go
+++ b/probes/probes_status_tmpl.go
@@ -26,8 +26,8 @@ var StatusTmpl = template.Must(template.New("statusTmpl").Parse(`
     <th>Type</th>
     <th>Interval</th>
     <th>Timeout</th>
-    <th>Targets</th>
-    <th>Probe Conf</th>
+    <th width="20%">Targets</th>
+    <th width="40%">Probe Conf</th>
     <th>Latency Unit</th>
     <th>Latency Distribution Lower Bounds (if configured) </th>
   </tr>

--- a/sysvars/sysvars.go
+++ b/sysvars/sysvars.go
@@ -75,6 +75,11 @@ func parseEnvVars(envVarsName string) map[string]string {
 	return envVars
 }
 
+// StartTime returns cloudprober's start time.
+func StartTime() time.Time {
+	return startTime
+}
+
 // Init initializes the sysvars module's global data structure. Init makes sure
 // to initialize only once, further calls are a no-op. If needed, userVars
 // can be passed to Init to add custom variables to sysVars. This can be useful

--- a/web/status_tmpl.go
+++ b/web/status_tmpl.go
@@ -3,7 +3,13 @@ package web
 var statusTmpl = `
 <html>
 
+<head>
 <style type="text/css">
+body {
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+	font-size: 14px;
+}
+
 table.status-list {
   border-collapse: collapse;
   border-spacing: 0;
@@ -20,6 +26,11 @@ pre {
 		word-wrap: break-word;
 }
 </style>
+</head>
+
+<b>Started</b>: {{.StartTime}} -- up {{.Uptime}}<br/>
+<b>Version</b>: {{.Version}}<br>
+<b>Config</b>: <a href="/config">/config</a><br>
 
 <h3>Probes:</h3>
 {{.ProbesStatus}}

--- a/web/web.go
+++ b/web/web.go
@@ -20,11 +20,14 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
+	"time"
 
 	"github.com/google/cloudprober"
+	"github.com/google/cloudprober/config/runconfig"
 	"github.com/google/cloudprober/probes"
 	"github.com/google/cloudprober/servers"
 	"github.com/google/cloudprober/surfacers"
+	"github.com/google/cloudprober/sysvars"
 )
 
 func execTmpl(tmpl *template.Template, v interface{}) template.HTML {
@@ -41,11 +44,16 @@ func Status() string {
 	var statusBuf bytes.Buffer
 
 	probeInfo, surfacerInfo, serverInfo := cloudprober.GetInfo()
+	startTime := sysvars.StartTime()
+	uptime := time.Since(startTime)
 
 	tmpl, _ := template.New("statusTmpl").Parse(statusTmpl)
 	tmpl.Execute(&statusBuf, struct {
-		ProbesStatus, ServersStatus, SurfacersStatus interface{}
+		Version, StartTime, Uptime, ProbesStatus, ServersStatus, SurfacersStatus interface{}
 	}{
+		Version:         runconfig.Version(),
+		StartTime:       startTime.Format(time.RFC1123),
+		Uptime:          uptime.String(),
 		ProbesStatus:    execTmpl(probes.StatusTmpl, probeInfo),
 		SurfacersStatus: execTmpl(surfacers.StatusTmpl, surfacerInfo),
 		ServersStatus:   execTmpl(servers.StatusTmpl, serverInfo),


### PR DESCRIPTION
= Show cloudprober version. This version is added the build time through the linker -X flag (if built using make)
= Show start time. Add a function to sysvars to fetch the start time.
= Show a link to the config handler (/config).
= Use better formatting (proto.MarshalTextString) for probe conf.

PiperOrigin-RevId: 225104565