### PR TITLE
Fix the status page:

### DIFF
--- a/probes/probes_status_tmpl.go
+++ b/probes/probes_status_tmpl.go
@@ -26,8 +26,8 @@ var StatusTmpl = template.Must(template.New("statusTmpl").Parse(`
     <th>Type</th>
     <th>Interval</th>
     <th>Timeout</th>
-    <th width="20%">Targets</th>
-    <th width="40%">Probe Conf</th>
+    <th width="20%%">Targets</th>
+    <th width="30%%">Probe Conf</th>
     <th>Latency Unit</th>
     <th>Latency Distribution Lower Bounds (if configured) </th>
   </tr>

--- a/servers/servers.go
+++ b/servers/servers.go
@@ -41,13 +41,11 @@ var StatusTmpl = template.Must(template.New("statusTmpl").Parse(`
 <table class="status-list">
   <tr>
     <th>Type</th>
-    <th>Name</th>
     <th>Conf</th>
   </tr>
   {{ range . }}
   <tr>
     <td>{{.Type}}</td>
-    <td>{{.Name}}</td>
     <td>
     {{if .Conf}}
       <pre>{{.Conf}}</pre>


### PR DESCRIPTION
= We need to escape '%'.
= Servers don't have a name field. Remove it from the template.

PiperOrigin-RevId: 225115973