### PR TITLE
Few more minor changes for the status page:

### DIFF
--- a/probes/probes.go
+++ b/probes/probes.go
@@ -40,6 +40,7 @@ import (
 	"github.com/google/cloudprober/targets/lameduck"
 	targetspb "github.com/google/cloudprober/targets/proto"
 	"github.com/google/cloudprober/validators"
+	"github.com/google/cloudprober/web/formatutils"
 )
 
 const (
@@ -200,14 +201,6 @@ func Init(probeProtobufs []*configpb.ProbeDef, globalTargetsOpts *targetspb.Glob
 			latencyDistLB = fmt.Sprintf("%v", opts.LatencyDist.Data().LowerBounds)
 		}
 
-		// If probeConf supports String() function, use it for status page.
-		probeConfStr := ""
-		if msg, ok := probeConf.(proto.Message); ok {
-			probeConfStr = proto.MarshalTextString(msg)
-		} else if stringer, ok := probeConf.(fmt.Stringer); ok {
-			probeConfStr = stringer.String()
-		}
-
 		probes[p.GetName()] = &ProbeInfo{
 			Probe:         probe,
 			Name:          p.GetName(),
@@ -217,7 +210,7 @@ func Init(probeProtobufs []*configpb.ProbeDef, globalTargetsOpts *targetspb.Glob
 			TargetsDesc:   p.Targets.String(),
 			LatencyDistLB: latencyDistLB,
 			LatencyUnit:   opts.LatencyUnit.String(),
-			ProbeConf:     probeConfStr,
+			ProbeConf:     formatutils.ConfToString(probeConf),
 		}
 	}
 

--- a/surfacers/surfacers.go
+++ b/surfacers/surfacers.go
@@ -36,6 +36,7 @@ import (
 	"github.com/google/cloudprober/surfacers/postgres"
 	"github.com/google/cloudprober/surfacers/prometheus"
 	"github.com/google/cloudprober/surfacers/stackdriver"
+	"github.com/google/cloudprober/web/formatutils"
 
 	surfacerpb "github.com/google/cloudprober/surfacers/proto"
 	surfacerspb "github.com/google/cloudprober/surfacers/proto"
@@ -185,18 +186,11 @@ func Init(sDefs []*surfacerpb.SurfacerDef) ([]*SurfacerInfo, error) {
 			return nil, err
 		}
 
-		confStr := ""
-		if conf != nil {
-			if stringer, ok := conf.(fmt.Stringer); ok {
-				confStr = stringer.String()
-			}
-		}
-
 		result = append(result, &SurfacerInfo{
 			Surfacer: s,
-			Type:     sDef.GetType().String(),
+			Type:     sType.String(),
 			Name:     sDef.GetName(),
-			Conf:     confStr,
+			Conf:     formatutils.ConfToString(conf),
 		})
 	}
 	return result, nil

--- a/web/formatutils/formatutils.go
+++ b/web/formatutils/formatutils.go
@@ -1,0 +1,34 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package formatutils provides web related utils for the cloudprober
+// sub-packages.
+package formatutils
+
+import (
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+)
+
+// ConfToString tries to convert the given conf object into a string.
+func ConfToString(conf interface{}) string {
+	if msg, ok := conf.(proto.Message); ok {
+		return proto.MarshalTextString(msg)
+	}
+	if stringer, ok := conf.(fmt.Stringer); ok {
+		return stringer.String()
+	}
+	return ""
+}


### PR DESCRIPTION
- Factor out the conf to string conversion into a utility function and use that everywhere.
- surfacers: Use the inferred surfacer type for SurfacerInfo objects.

PiperOrigin-RevId: 225272663