### PR TITLE
Copy compression buffer's bytes into a new location rather than just copying the reference.

### DIFF
--- a/surfacers/file/file.go
+++ b/surfacers/file/file.go
@@ -140,7 +140,8 @@ func compressBytes(inBytes []byte) (string, error) {
 func (c *compressionBuffer) flush() {
 	// Retrieve bytes from the buffer (c.buf) and reset it.
 	c.Lock()
-	inBytes := c.buf.Bytes()
+	inBytes := make([]byte, len(c.buf.Bytes()))
+	copy(inBytes, c.buf.Bytes())
 	c.buf.Reset()
 	c.lines = 0
 	c.Unlock()


### PR DESCRIPTION
Golang's bytes.Buffer.Bytes() has a rather non-obvious behavior. It doesn't make a copy of the bytes but simply returns a reference to the underlying location. If we write to the same buffer again before bytes have been compressed, we'll have a case of data corruption.

PiperOrigin-RevId: 228738717