### PR TITLE
Add an environment variable to skip UDP probe tests for OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ matrix:
   - os: linux
     dist: trusty
   - os: osx
+    env: EXTRA_TEST_FLAGS="-tag skip_udp_probe_test"
 
 language: go
 
@@ -13,7 +14,7 @@ install:
  - go get -t ./...
 
 script:
- - go test -v -race -covermode=atomic ./...
+ - go test ${EXTRA_TEST_FLAGS} -v -race -covermode=atomic ./...
 
 go_import_path: github.com/google/cloudprober
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
   - os: linux
     dist: trusty
   - os: osx
-    env: EXTRA_TEST_FLAGS="-tag skip_udp_probe_test"
+    env: EXTRA_TEST_FLAGS="-tags skip_udp_probe_test"
 
 language: go
 


### PR DESCRIPTION
See https://github.com/google/cloudprober/issues/199.