### PR TITLE
servers/http: Don't wake up statskeeper goroutine for every request.

### DIFF
--- a/servers/http/http_test.go
+++ b/servers/http/http_test.go
@@ -59,9 +59,10 @@ func testServer(ctx context.Context, t *testing.T, insName string, ldLister lame
 		statsInterval: 2 * time.Second,
 		instanceName:  insName,
 		ldLister:      ldLister,
-		staticURLResTable: map[string]string{
-			"/":         OK,
-			"/instance": insName,
+		reqMetric:     metrics.NewMap("url", metrics.NewInt(0)),
+		staticURLResTable: map[string][]byte{
+			"/":         []byte(OK),
+			"/instance": []byte(insName),
 		},
 	}
 


### PR DESCRIPTION
= Instead, update the request metric in the request handler itself.

= Also, while here, replace fmt.Fprintf by w.Write in request handler. fmt makes arguments (response string) escape to heap and requires reflection which isn't the fastest thing.

= Store static responses as bytes, rather than strings to avoid one conversion.

I see minor improvements to CPU usage after this change.

PiperOrigin-RevId: 230983788