### PR TITLE
Change logger.{Debug, Info, Warning, Error} functions to take string …

### DIFF
--- a/servers/http/http.go
+++ b/servers/http/http.go
@@ -88,7 +88,7 @@ func (s *Server) lameduckHandler(w http.ResponseWriter) {
 func (s *Server) healthcheckHandler(w http.ResponseWriter) {
 	lameduck, err := s.lameduckStatus()
 	if err != nil {
-		s.l.Error(err)
+		s.l.Error(err.Error())
 	}
 	if lameduck {
 		http.Error(w, "lameduck", http.StatusServiceUnavailable)
@@ -137,7 +137,7 @@ func New(initCtx context.Context, c *configpb.ServerConf, l *logger.Logger) (*Se
 	// If we are not able get the default lameduck lister, we only log a warning.
 	ldLister, err := lameduck.GetDefaultLister()
 	if err != nil {
-		l.Warning(err)
+		l.Warning(err.Error())
 	}
 
 	if c.GetProtocol() == configpb.ServerConf_HTTPS {


### PR DESCRIPTION
…arg instead of interface{}.

interface{} type makes all arguments to go to heap. We don't really use JSON for logging so using interface for the argument is not adding much value.

Note: Changing ping probe to use non-formatting logging function after this change removes 16 heap escapes, mostly from the hot-path.
PiperOrigin-RevId: 233895886