### PR TITLE
Fix format string in a couple of places.

### DIFF
--- a/surfacers/prometheus/prometheus_test.go
+++ b/surfacers/prometheus/prometheus_test.go
@@ -46,11 +46,11 @@ func verify(t *testing.T, ps *PromSurfacer, expectedMetrics map[string]testData)
 	for k, td := range expectedMetrics {
 		pm := ps.metrics[td.metricName]
 		if pm == nil {
-			t.Errorf("Metric %s not found in the prometheus metrics: %q", k, ps.metrics)
+			t.Errorf("Metric %s not found in the prometheus metrics: %v", k, ps.metrics)
 			continue
 		}
 		if pm.data[k] == nil {
-			t.Errorf("Data key %s not found in the prometheus metrics: %q", k, pm.data)
+			t.Errorf("Data key %s not found in the prometheus metrics: %v", k, pm.data)
 			continue
 		}
 		if pm.data[k].value != td.value {

--- a/validators/http/http_test.go
+++ b/validators/http/http_test.go
@@ -66,7 +66,7 @@ func TestParseStatusCodeConfig(t *testing.T) {
 	for _, s := range invalidTestStr {
 		numRanges, err := parseStatusCodeConfig(s)
 		if err == nil {
-			t.Errorf("parseStatusCodeConfig(%s): expected error but got response: %q", s, numRanges)
+			t.Errorf("parseStatusCodeConfig(%s): expected error but got response: %v", s, numRanges)
 		}
 	}
 }


### PR DESCRIPTION
Go 1.12 (rightly) enforces the formatting args now.

PiperOrigin-RevId: 233967054