### PR TITLE
Extend external probe to parse more metrics types from payload:

### DIFF
--- a/metrics/map_test.go
+++ b/metrics/map_test.go
@@ -74,3 +74,25 @@ func TestMap(t *testing.T) {
 		"500": 1,
 	})
 }
+
+func TestMapString(t *testing.T) {
+	m := NewMap("lat", NewFloat(0))
+	m.IncKeyBy("p99", NewFloat(4000))
+	m.IncKeyBy("p50", NewFloat(20))
+
+	s := m.String()
+	expectedString := "map:lat,p50:20.000,p99:4000.000"
+	if s != expectedString {
+		t.Errorf("m.String()=%s, expected=%s", s, expectedString)
+	}
+
+	m2, err := ParseMapFromString(s)
+	if err != nil {
+		t.Errorf("ParseMapFromString(%s) returned error: %v", s, err)
+	}
+
+	s1 := m2.String()
+	if s1 != s {
+		t.Errorf("ParseMapFromString(%s).String() = %s, expected = %s", s, s1, s)
+	}
+}


### PR DESCRIPTION
= Add a ParseMapFromString function to metrics package.
= In payload_metrics, add support for maps, strings and distributions. Numerical values were already supported. Note that all numerical values are parsed as floats.

PiperOrigin-RevId: 245525444