### PR TITLE
Fix a recently introduced bug in stackdriver surfacer initialization.

### DIFF
--- a/surfacers/stackdriver/stackdriver.go
+++ b/surfacers/stackdriver/stackdriver.go
@@ -129,7 +129,7 @@ func New(config *configpb.SurfacerConf, l *logger.Logger) (*SDSurfacer, error) {
 		return nil, err
 	}
 
-	if s.c.Batch != nil {
+	if s.c != nil && s.c.Batch != nil {
 		s.l.Warningf("Setting 'batch' doesn't do anything anymore. Batching is always enabled. This field will be removed after release v0.10.3.")
 	}
 


### PR DESCRIPTION
While checking if "batch" option has been set, first check if config itself has been provided.

PiperOrigin-RevId: 253042872