### PR TITLE
Ping probe: Update results map even for the targets that don't resolve.

### DIFF
--- a/probes/ping/ping_test.go
+++ b/probes/ping/ping_test.go
@@ -153,7 +153,6 @@ func sendAndCheckPackets(p *Probe, t *testing.T) {
 	tic := newTestICMPConn(p.c, p.targets)
 	p.conn = tic
 	trackerChan := make(chan bool, int(p.c.GetPacketsPerProbe())*len(p.targets))
-	p.resolveTargets()
 	runID := p.newRunID()
 	p.sendPackets(runID, trackerChan)
 
@@ -247,7 +246,6 @@ func TestSendPacketsIPv6ToIPv4Hosts(t *testing.T) {
 	tic := newTestICMPConn(c, p.targets)
 	p.conn = tic
 	trackerChan := make(chan bool, int(c.GetPacketsPerProbe())*len(p.targets))
-	p.resolveTargets()
 	p.sendPackets(p.newRunID(), trackerChan)
 	for _, target := range p.targets {
 		if len(tic.sentPackets[target]) != 0 {


### PR DESCRIPTION
Earlier we were skipping updating any target specific data structure if target fails to resolve. We should update the results map regardless of wether target resolves or not.

See https://github.com/google/cloudprober/issues/264 for more details.

PiperOrigin-RevId: 259473838