### PR TITLE
Provide a mechanism to find the local RDS server and if rds_server_address is not given, use that.

### DIFF
--- a/config/runconfig/runconfig.go
+++ b/config/runconfig/runconfig.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"sync"
 
+	rdsserver "github.com/google/cloudprober/targets/rds/server"
 	"google.golang.org/grpc"
 )
 
@@ -29,8 +30,9 @@ import (
 // e.g., servers injected by external cloudprober users.
 type runConfig struct {
 	sync.RWMutex
-	grpcSrv *grpc.Server
-	version string
+	grpcSrv   *grpc.Server
+	version   string
+	rdsServer *rdsserver.Server
 }
 
 var rc runConfig
@@ -68,4 +70,20 @@ func Version() string {
 	rc.RLock()
 	defer rc.RUnlock()
 	return rc.version
+}
+
+// SetLocalRDSServer stores local RDS server in the runconfig. It can later
+// be retrieved throuhg LocalRDSServer().
+func SetLocalRDSServer(srv *rdsserver.Server) {
+	rc.Lock()
+	defer rc.Unlock()
+	rc.rdsServer = srv
+}
+
+// LocalRDSServer returns the local RDS server, set through the
+// SetLocalRDSServer() call.
+func LocalRDSServer() *rdsserver.Server {
+	rc.RLock()
+	defer rc.RUnlock()
+	return rc.rdsServer
 }

--- a/targets/targets_test.go
+++ b/targets/targets_test.go
@@ -236,9 +236,9 @@ func TestRDSClientConf(t *testing.T) {
 		wantAddr   string
 	}{
 		{
-			desc:     "address is not initialized",
+			desc:     "Error as RDS server address is not initialized",
 			provider: provider,
-			wantAddr: "",
+			wantErr:  true,
 		},
 		{
 			desc:       "Pick global address",
@@ -276,7 +276,7 @@ func TestRDSClientConf(t *testing.T) {
 				globalOpts.RdsServerAddress = proto.String(r.globalAddr)
 			}
 
-			cc, err := targets.RDSClientConf(pb, globalOpts)
+			_, cc, err := targets.RDSClientConf(pb, globalOpts)
 			if (err != nil) != r.wantErr {
 				t.Errorf("wantErr: %v, got err: %v", r.wantErr, err)
 			}


### PR DESCRIPTION
= As we standardize more towards RDS targets (and hence a common configuration format), the case of running a local RDS server will become more common. For example, for kubernetes targets, we are going to support only RDS format and that requires running an RDS server, either local or remote.

= Advantage of sharing the entire RDS server (through runconfig), instead of just the server address, is that client can directly use the server without going through the gRPC server.

PiperOrigin-RevId: 267216603