### PR TITLE
Fix incorrect link to server.proto

### DIFF
--- a/concepts/probe/index.html
+++ b/concepts/probe/index.html
@@ -427,7 +427,7 @@ In this mode, external program is expected to run in server mode. Cloudprober
 automatically starts the external program if it&rsquo;s not running at the time of
 the probe execution. Cloudprober and external probe process communicate with
 each other over stdin/stdout using protobuf messages defined in
-<a href="https://github.com/google/cloudprober/blob/master/probes/external/serverutils/server.proto">server.proto</a>.</p></li>
+<a href="https://github.com/google/cloudprober/blob/master/probes/external/proto/server.proto">server.proto</a>.</p></li>
 </ul>
 
 


### PR DESCRIPTION
This file was renamed in commit ec30bb3ad30547ed4db7b1627dd7b7ff1b5587b0.