### PR TITLE
Static Site Tweaks

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -3,13 +3,9 @@ languageCode = "en-us"
 title = "Cloudprober"
 theme = "hugo-material-docs"
 googleAnalytics = "UA-79661-8"
-pygmentsUseClassic = true
-pygmentsStyle = "default"
+pygmentsUseClasses = true
 canonifyURLs = true
 
 [params]
   provider = "GitHub"
   repo_url = "https://github.com/google/cloudprober"
-
-
-

--- a/docs/content/concepts/probe.md
+++ b/docs/content/concepts/probe.md
@@ -111,4 +111,4 @@ External probe can be configured in two modes:
    automatically starts the external program if it's not running at the time of
    the probe execution. Cloudprober and external probe process communicate with
    each other over stdin/stdout using protobuf messages defined in
-   [server.proto](https://github.com/google/cloudprober/blob/master/probes/external/serverutils/server.proto).
+   [probes/external/proto/server.proto](https://github.com/google/cloudprober/blob/master/probes/external/proto/server.proto).

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -10,10 +10,11 @@ title: Getting Started
 * __From Source__\
 If you have Go 1.9 or higher installed and GOPATH environment variable properly set up, you
 can download and install `cloudprober` using the following commands:
-```shell
+
+{{< highlight bash>}}
 go get github.com/google/cloudprober
 GOBIN=$GOPATH/bin go install $GOPATH/src/github.com/google/cloudprober/cmd/cloudprober.go
-```
+{{< / highlight >}}
 
 * __Pre-built Binaries__\
 You can download the pre-built binaries for Linux, Mac OS and Windows from the
@@ -21,11 +22,11 @@ project's [releases page](http://github.com/google/cloudprober/releases).
 
 * __Docker Image__\
 You can download and run the latest docker image using the following command:
-```shell
+{{< highlight bash>}}
 docker run --net host cloudprober/cloudprober
 # Note: --net host provides better network performance and makes port forwarding
 # management easier.
-```
+{{< / highlight >}}
 
 ## Configuration
 Without any config, cloudprober will run only the "sysvars" module (no probes)
@@ -38,7 +39,7 @@ through the environment variable *CLOUDPROBER_HOST*).
 Since sysvars variables are not very interesting themselves, lets add a simple
 config that probes Google's homepage:
 
-```shell
+{{< highlight bash >}}
 # Write config to a file in /tmp
 cat > /tmp/cloudprober.cfg <<EOF
 probe {
@@ -51,7 +52,7 @@ probe {
   timeout_msec: 1000   # 1s
 }
 EOF
-```
+{{< / highlight >}}
 
 This config adds an HTTP probe that accesses the homepage of the target
 "www.google.com" every 5s with a timeout of 1s. Cloudprober configuration is
@@ -62,16 +63,16 @@ proto file: [config.proto
 Assuming that you saved this file at `/tmp/cloudprober.cfg` (following the
 command above), you can have cloudprober use this config file using the following command line:
 
-```shell
+{{< highlight bash >}}
 ./cloudprober --config_file /tmp/cloudprober.cfg
-```
+{{< / highlight >}}
 
 You can have the standard docker image use this config using the following
 command:
-```
+{{< highlight bash >}}
 docker run --net host -v /tmp/cloudprober.cfg:/etc/cloudprober.cfg \
     cloudprober/cloudprober
-```
+{{< / highlight >}}
 
 _Note: While running on GCE, cloudprober config can also be provided through a
 custom metadata attribute: cloudprober\_config_.
@@ -87,11 +88,11 @@ locally_): http://localhost:9313/status.
 You should be able to see the generated metrics at http://locahost:9313/metrics
 (prometheus format) and the stdout (cloudprober format):
 
-```
+{{< highlight text >}}
 cloudprober 1500590430132947313 1500590520 labels=ptype=http,probe=google-http,dst=www.google.com total=17 success=17 latency=1808357 timeouts=0 resp-code=map:code,200:17
 cloudprober 1500590430132947314 1500590530 labels=ptype=sysvars,probe=sysvars hostname="manugarg-workstation" uptime=100
 cloudprober 1500590430132947315 1500590530 labels=ptype=http,probe=google-http,dst=www.google.com total=19 success=19 latency=2116441 timeouts=0 resp-code=map:code,200:19
-```
+{{< / highlight >}}
 
 This information is good for debugging monitoring issues, but to really make
 sense of this data, you'll need to feed this data to another monitoring system
@@ -103,7 +104,7 @@ to make pretty graphs for us.
 Download prometheus binary from its [release page](https://prometheus.io/download/). You can use a config like the following
 to scrape cloudprober running on the same host.
 
-```shell
+{{< highlight bash >}}
 # Write config to a file in /tmp
 cat > /tmp/prometheus.yml <<EOF
 scrape_configs:
@@ -113,9 +114,9 @@ scrape_configs:
       - targets: ['localhost:9313']
 EOF
 
-Start prometheus:
+# Start prometheus:
 ./prometheus --config.file=/tmp/prometheus.yml
-```
+{{< / highlight >}}
 
 Prometheus provides a web interface at http://localhost:9090. You can explore
 the probe metrics and build useful graphs through this interface. All probes

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -129,10 +129,11 @@ in cloudprober export at least 3 counters:
 
 Using these counters, probe failure ratio and average latency can be calculated
 as:
-```
+
+{{< highlight text >}}
 failure_ratio = (rate(total) - rate(success)) / rate(total)
 avg_latency = rate(latency) / rate(success)
-```
+{{< / highlight >}}
 
 Assuming that prometheus is running at `localhost:9090`, graphs depicting
 failure ratio and latency over time can be accessed in prometheus at: [this url ](http://localhost:9090/graph?g0.range_input=1h&g0.expr=(rate(total%5B1m%5D)+-+rate(success%5B1m%5D))+%2F+rate(total%5B1m%5D)&g0.tab=0&g1.range_input=1h&g1.expr=rate(latency%5B1m%5D)+%2F+rate(success%5B1m%5D)+%2F+1000&g1.tab=0).

--- a/docs/content/how-to/extensions.md
+++ b/docs/content/how-to/extensions.md
@@ -240,7 +240,7 @@ cloudprober 1540848577649139849 1540848897 labels=ptype=sysvars,probe=sysvars go
 {{< / highlight >}}
 
 You can import this data in prometheus following the process outlined at:
-[Running Prometheus]({{< ref "getting-started.md#running-prometheus" >}}).
+[Running Prometheus]({{< ref "/getting-started.md#running-prometheus" >}}).
 
 ## Conclusion
 

--- a/docs/content/how-to/extensions.md
+++ b/docs/content/how-to/extensions.md
@@ -91,9 +91,6 @@ Now let's implement our probe type. Our probe type should implement the
 [probes.Probe](https://godoc.org/github.com/google/cloudprober/probes#Probe) interface.
 
 {{< highlight go >}}
-// Full listing:
-// github.com/google/cloudprober/examples/extensions/myprober/myprobe/myprobe.go
-
 package myprobe
 
 // Probe holds aggregate information about all probe runs, per-target.
@@ -163,7 +160,8 @@ func (p *Probe) runProbe(ctx context.Context) {
 }
 {{< / highlight >}}
 
-(Full listing: <https://github.com/google/cloudprober/blob/master/examples/extensions/myprober/myprobe/myprobe.go>)
+Full example in
+[examples/extensions/myprober/myprobe/myprobe.go](https://github.com/google/cloudprober/blob/master/examples/extensions/myprober/myprobe/myprobe.go).
 
 This probe type sets or gets (depending on the configuration) a key-valye in
 redis and records success and time taken (latency) if operation is successful.
@@ -171,9 +169,6 @@ redis and records success and time taken (latency) if operation is successful.
 ## Implement a cloudprober binary that includes support for our probe
 
 {{< highlight go >}}
-// Full listing:
-// github.com/google/cloudprober/examples/extensions/myprober/myprober.go
-
 package main
 
 ...
@@ -199,7 +194,9 @@ func main() {
   select {}
 }
 {{< / highlight >}}
-(Full listing: <https://github.com/google/cloudprober/blob/master/examples/extensions/myprober/myprober.go>)
+
+Full example in
+[examples/extensions/myprober/myprober.go](https://github.com/google/cloudprober/blob/master/examples/extensions/myprober/myprober.go).
 
 Let's write a test config that uses the newly defined probe type:
 
@@ -219,7 +216,9 @@ probe {
   }
 }
 {{< / highlight >}}
-(Full listing: <https://github.com/google/cloudprober/blob/master/examples/extensions/myprober/myprober.cfg>)
+
+Full example in
+[examples/extensions/myprober/myprober.cfg](https://github.com/google/cloudprober/blob/master/examples/extensions/myprober/myprober.cfg).
 
 Let's compile our prober and run it with the above config:
 

--- a/docs/content/how-to/extensions.md
+++ b/docs/content/how-to/extensions.md
@@ -23,7 +23,7 @@ this probe-type provides a way to test redis server functionality and it takes
 the following options - operation (GET vs SET vs DELETE), key, value. This
 probe's configuration looks like this:
 
-{{< highlight bash >}}
+{{< highlight protobuf >}}
 probe {
   name: "redis_set"
   type: EXTENSION
@@ -73,12 +73,11 @@ message ProbeConf {
 extend cloudprober.probes.ProbeDef {
   optional ProbeConf redis_probe = 200;
 }
-
 {{< / highlight >}}
 
 Let's generate Go code for this protobuf:
 
-{{< highlight shell >}}
+{{< highlight bash >}}
 # From the myprober directory
 protoc --go_out=.,import_path=myprobe:. --proto_path=$GOPATH/src:. myprobe/*.proto
 
@@ -230,7 +229,7 @@ go build ./myprober.go
 {{< / highlight >}}
 
 you should see an output like the following:
-```
+{{< highlight text >}}
 cloudprober 1540848577649139842 1540848587 labels=ptype=redis,probe=redis_set,dst=localhost:6379 total=31 success=31 latency=70579.823
 cloudprober 1540848577649139843 1540848887 labels=ptype=sysvars,probe=sysvars hostname="manugarg-macbookpro5.roam.corp.google.com" start_timestamp="1540848577"
 cloudprober 1540848577649139844 1540848887 labels=ptype=sysvars,probe=sysvars uptime_msec=310007.784 gc_time_msec=0.000 mallocs=14504 frees=826
@@ -239,7 +238,7 @@ cloudprober 1540848577649139846 1540848587 labels=ptype=redis,probe=redis_set,ds
 cloudprober 1540848577649139847 1540848897 labels=ptype=sysvars,probe=sysvars hostname="manugarg-macbookpro5.roam.corp.google.com" start_timestamp="1540848577"
 cloudprober 1540848577649139848 1540848897 labels=ptype=sysvars,probe=sysvars uptime_msec=320006.541 gc_time_msec=0.000 mallocs=14731 frees=844
 cloudprober 1540848577649139849 1540848897 labels=ptype=sysvars,probe=sysvars goroutines=12 mem_stats_sys_bytes=7211256
-```
+{{< / highlight >}}
 
 You can import this data in prometheus following the process outlined at:
 [Running Prometheus]({{< ref "getting-started.md#running-prometheus" >}}).

--- a/docs/content/how-to/external-probe.md
+++ b/docs/content/how-to/external-probe.md
@@ -57,7 +57,8 @@ get_latency_ms 2.173560
 ## Configuration
 Here is the external probe configuration that makes use of this program:
 
-(Full listing: https://github.com/google/cloudprober/blob/master/examples/external/cloudprober.cfg)
+Full example in [examples/external/cloudprober.cfg](https://github.com/google/cloudprober/blob/master/examples/external/cloudprober.cfg).
+
 {{< highlight protobuf >}}
 # Run an external probe that executes a command from the current working
 # directory.
@@ -91,7 +92,7 @@ You can import this data in prometheus following the process outlined at:
 ## Distributions
 How nice will it be if we could find distribution of the set and get latency. If tail latency was too high, it could explain the random timeouts in your application. Fortunately, it's very easy to create distributions in Cloudprober. You just need to add the following section to your probe definition:
 
-(Full listing: https://github.com/google/cloudprober/blob/master/examples/external/cloudprober_aggregate.cfg)
+Full example in [examples/external/cloudprober_aggregate.cfg](https://github.com/google/cloudprober/blob/master/examples/external/cloudprober_aggregate.cfg).
 
 {{< highlight protobuf >}}
 # Run an external probe and aggregate metrics in cloudprober.

--- a/docs/content/how-to/external-probe.md
+++ b/docs/content/how-to/external-probe.md
@@ -17,16 +17,16 @@ in a redis server. Here is the `main` function of such a probe:
 
 {{< highlight go >}}
 func main() {
-	var client redis.Client
-	var key = "hello"
-	startTime := time.Now()
-	client.Set(key, []byte("world"))
-	fmt.Printf("set_latency_ms %f\n", float64(time.Since(startTime).Nanoseconds())/1e6)
+    var client redis.Client
+    var key = "hello"
+    startTime := time.Now()
+    client.Set(key, []byte("world"))
+    fmt.Printf("set_latency_ms %f\n", float64(time.Since(startTime).Nanoseconds())/1e6)
 
-	startTime = time.Now()
-	val, _ := client.Get("hello")
-	log.Printf("%s=%s", key, string(val))
-	fmt.Printf("get_latency_ms %f\n", float64(time.Since(startTime).Nanoseconds())/1e6)
+    startTime = time.Now()
+    val, _ := client.Get("hello")
+    log.Printf("%s=%s", key, string(val))
+    fmt.Printf("get_latency_ms %f\n", float64(time.Since(startTime).Nanoseconds())/1e6)
 }
 {{< / highlight >}}
 
@@ -95,24 +95,24 @@ How nice will it be if we could find distribution of the set and get latency. If
 
 {{< highlight bash >}}
 # Run an external probe and aggregate metrics in cloudprober.
-    ...
-    output_metrics_options {
-      aggregate_in_cloudprober: true
+...
+output_metrics_options {
+  aggregate_in_cloudprober: true
 
-      # Create distributions for get_latency_ms and set_latency_ms.
-      dist_metric {
-        key: "get_latency_ms"
-        value: {
-          explicit_buckets: "0.1,0.2,0.4,0.6,0.8,1.0,2.0"
-        }
-      }
-      dist_metric {
-        key: "set_latency_ms"
-        value: {
-          explicit_buckets: "0.1,0.2,0.4,0.6,0.8,1.0,2.0"
-        }
-      }
+  # Create distributions for get_latency_ms and set_latency_ms.
+  dist_metric {
+    key: "get_latency_ms"
+    value: {
+      explicit_buckets: "0.1,0.2,0.4,0.6,0.8,1.0,2.0"
     }
+  }
+  dist_metric {
+    key: "set_latency_ms"
+    value: {
+      explicit_buckets: "0.1,0.2,0.4,0.6,0.8,1.0,2.0"
+    }
+  }
+}
 {{< / highlight >}}
 
 This configuration adds options to aggregate the metrics in the cloudprober and configures "get\_latency\_ms" and "set\_latency\_ms" as distribution metrics with explicit buckets. Cloudprober will now build cumulative distributions using

--- a/docs/content/how-to/external-probe.md
+++ b/docs/content/how-to/external-probe.md
@@ -58,7 +58,7 @@ get_latency_ms 2.173560
 Here is the external probe configuration that makes use of this program:
 
 (Full listing: https://github.com/google/cloudprober/blob/master/examples/external/cloudprober.cfg)
-{{< highlight bash >}}
+{{< highlight protobuf >}}
 # Run an external probe that executes a command from the current working
 # directory.
 probe {
@@ -74,7 +74,7 @@ probe {
 
 Running it through cloudprober, you'll see the following output:
 
-```
+{{< highlight bash >}}
 # Launch cloudprober
 cloudprober --config_file=cloudprober.cfg
 
@@ -83,7 +83,7 @@ cloudprober 1519..1 1519583408 labels=ptype=external,probe=redis_probe,dst= set_
 cloudprober 1519..2 1519583410 labels=ptype=external,probe=redis_probe,dst= success=2 total=2 latency=30585.915
 cloudprober 1519..3 1519583410 labels=ptype=external,probe=redis_probe,dst= set_latency_ms=0.636 get_latency_ms=0.994
 cloudprober 1519..4 1519583412 labels=ptype=external,probe=redis_probe,dst= success=3 total=3 latency=42621.871
-```
+{{< / highlight >}}
 
 You can import this data in prometheus following the process outlined at:
 [Running Prometheus]({{< ref "/getting-started.md#running-prometheus" >}}). Before doing that, let's make it more interesting.
@@ -93,7 +93,7 @@ How nice will it be if we could find distribution of the set and get latency. If
 
 (Full listing: https://github.com/google/cloudprober/blob/master/examples/external/cloudprober_aggregate.cfg)
 
-{{< highlight bash >}}
+{{< highlight protobuf >}}
 # Run an external probe and aggregate metrics in cloudprober.
 ...
 output_metrics_options {

--- a/docs/content/how-to/external-probe.md
+++ b/docs/content/how-to/external-probe.md
@@ -125,7 +125,7 @@ grafana dashboard built using these metrics.
 
 The probe that we created above forks out a new `redis_probe` process for every
 probe cycle. This can get expensive if probe frequency is high and the process is big (e.g. a Java binary). Also, what if you want to keep some state across probes, for example, lets say you want to monitor performance over HTTP/2 where you keep using the same TCP connection for multiple HTTP requests. A new process
-everytime makes keeping state impossible.
+every time makes keeping state impossible.
 
 External probe's server mode provides a way to run the external probe process in daemon mode. Cloudprober communicates with this process over stdout/stdin (connected with OS pipes), using serialized protobuf messages. Cloudprober comes with a serverutils package that makes it easy to build external probe servers in Go.
 

--- a/docs/themes/hugo-material-docs/static/stylesheets/highlight/highlight.css
+++ b/docs/themes/hugo-material-docs/static/stylesheets/highlight/highlight.css
@@ -5,6 +5,9 @@
 .article pre code {
 	color: rgba(0, 0, 0, 0.8) !important;
 }
+.article code {
+  background: none !important; /* pre already has a background color */
+}
 
 
 /*	


### PR DESCRIPTION
This also includes the fix in https://github.com/google/cloudprober/pull/281 which I incorrectly applied to the hugo output.

Using `pygmentsUseClasses = true` fixes very incorrect code highlighting shown when using `hugo server`, before:
![idYDm8SkgEJ](https://user-images.githubusercontent.com/80069/65175430-dd698700-da20-11e9-9d0c-f1743c9955a5.png)
after:
![whJYDpdVWPX](https://user-images.githubusercontent.com/80069/65175510-fffba000-da20-11e9-8e48-0bb68a7410ea.png)

