### PR TITLE
A few logging fixes.

### DIFF
--- a/targets/lameduck/lameduck.go
+++ b/targets/lameduck/lameduck.go
@@ -254,6 +254,10 @@ func (li *lister) List() []string {
 	for _, cl := range li.clients {
 		result = append(result, cl.List()...)
 	}
+
+	if len(result) != 0 {
+		li.l.Infof("Lameducked targets: %v", result)
+	}
 	return result
 }
 

--- a/targets/rds/server/gcp/pubsub.go
+++ b/targets/rds/server/gcp/pubsub.go
@@ -168,11 +168,12 @@ func newPubSubMsgsLister(project string, c *configpb.PubSubMessages, l *logger.L
 		lister.subs[sub.GetName()] = s
 		lister.cache[sub.GetName()] = make(map[string]time.Time)
 
+		lister.l.Infof("pubsub: Receiving pub/sub messages for project (%s) and subscription (%s)", lister.project, sub.GetName())
 		go s.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
 			lister.mu.Lock()
 			defer lister.mu.Unlock()
 
-			lister.l.Infof("Adding message with name: %s, message id: %s, publish time: %s", msg.Attributes["name"], msg.ID, msg.PublishTime)
+			lister.l.Infof("pubsub: Adding message with name: %s, message id: %s, publish time: %s", msg.Attributes["name"], msg.ID, msg.PublishTime)
 			lister.cache[sub.GetName()][msg.Attributes["name"]] = msg.PublishTime
 			msg.Ack()
 		})


### PR DESCRIPTION
= Log the list of lameducked targets.
= Log an INFO log before starting the receiver for the pub/sub subscription.
= Don't log for each run of rtc_variables.expand().

PiperOrigin-RevId: 275397194