### PR TITLE
Refactor statskeeper into its own package.

### DIFF
--- a/probes/common/statskeeper/statskeeper.go
+++ b/probes/common/statskeeper/statskeeper.go
@@ -1,0 +1,95 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package statskeeper implements utilities that are shared across multiple probe
+types.
+*/
+package statskeeper
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/cloudprober/metrics"
+	"github.com/google/cloudprober/probes/options"
+)
+
+// ProbeResult represents results of a probe run.
+type ProbeResult interface {
+	// Metrics converts ProbeResult into a map of the metrics that is suitable for
+	// working with metrics.EventMetrics.
+	Metrics() *metrics.EventMetrics
+
+	// Target returns the target associated with the probe result.
+	Target() string
+}
+
+// StatsKeeper manages and outputs probe results.
+//
+// Typical StatsKeeper usage pattern is that the probes start a StatsKeeper
+// goroutine in the beginning. StatsKeeper goroutine manages access to the
+// per-target cumulative metrics. It listens on an input channel for probe
+// results and updates the metrics whenever a new probe result is obtained.
+// It exports aggregate probe statistics to the output channel, at intervals
+// controlled by a Ticker. These two operations are mutually exclusive. This
+// is the only goroutine that accesses the metrics. StatsKeeper runs
+// indefinitely, across multiple probe runs, and should not stop during normal
+// program execution.
+//
+// If we get a new result on resultsChan, update the probe statistics.
+// If we get a timer tick on doExport, export probe data for all targets.
+// If context is canceled, return.
+//
+// Note that StatsKeeper calls a function (targetsFunc) to get the list of the
+// targets for exporting results,  instead of getting a static list in the
+// arguments. We do that as the list of targets is usually dynamic and is
+// updated on a regular basis.
+func StatsKeeper(ctx context.Context, ptype, name string, opts *options.Options, targetsFunc func() []string, resultsChan <-chan ProbeResult, dataChan chan<- *metrics.EventMetrics) {
+	targetMetrics := make(map[string]*metrics.EventMetrics)
+	exportTicker := time.NewTicker(opts.StatsExportInterval)
+	defer exportTicker.Stop()
+
+	for {
+		select {
+		case result := <-resultsChan:
+			// result is a ProbeResult
+			t := result.Target()
+			if targetMetrics[t] == nil {
+				targetMetrics[t] = result.Metrics()
+				continue
+			}
+			err := targetMetrics[t].Update(result.Metrics())
+			if err != nil {
+				opts.Logger.Errorf("Error adding metrics from the probe result for the target: %s. Err: %v", t, err)
+			}
+		case ts := <-exportTicker.C:
+			for _, t := range targetsFunc() {
+				em := targetMetrics[t]
+				if em != nil {
+					em.AddLabel("ptype", ptype)
+					em.AddLabel("probe", name)
+					em.AddLabel("dst", t)
+					em.Timestamp = ts
+					if opts.LogMetrics != nil {
+						opts.LogMetrics(em)
+					}
+					dataChan <- em.Clone()
+				}
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/probes/common/statskeeper/statskeeper_test.go
+++ b/probes/common/statskeeper/statskeeper_test.go
@@ -1,0 +1,113 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statskeeper
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/cloudprober/metrics"
+	"github.com/google/cloudprober/probes/options"
+)
+
+// probeRunResult captures the results of a single probe run. The way we work with
+// stats makes sure that probeRunResult and its fields are not accessed concurrently
+// (see documentation with statsKeeper below). That's the reason we use metrics.Int
+// types instead of metrics.AtomicInt.
+type probeRunResult struct {
+	target string
+	sent   metrics.Int
+	rcvd   metrics.Int
+	rtt    metrics.Int // microseconds
+}
+
+func newProbeRunResult(target string) probeRunResult {
+	return probeRunResult{
+		target: target,
+	}
+}
+
+// Metrics converts probeRunResult into a map of the metrics that is suitable for
+// working with metrics.EventMetrics.
+func (prr probeRunResult) Metrics() *metrics.EventMetrics {
+	return metrics.NewEventMetrics(time.Now()).
+		AddMetric("sent", &prr.sent).
+		AddMetric("rcvd", &prr.rcvd).
+		AddMetric("rtt", &prr.rtt)
+}
+
+// Target returns the p.target.
+func (prr probeRunResult) Target() string {
+	return prr.target
+}
+
+func TestStatsKeeper(t *testing.T) {
+	targets := []string{
+		"target1",
+		"target2",
+	}
+	pType := "test"
+	pName := "testProbe"
+	exportInterval := 2 * time.Second
+
+	resultsChan := make(chan ProbeResult, len(targets))
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
+	targetsFunc := func() []string {
+		return targets
+	}
+	dataChan := make(chan *metrics.EventMetrics, len(targets))
+
+	opts := &options.Options{
+		StatsExportInterval: exportInterval,
+	}
+	go StatsKeeper(ctx, pType, pName, opts, targetsFunc, resultsChan, dataChan)
+
+	for _, t := range targets {
+		prr := newProbeRunResult(t)
+		prr.sent.Inc()
+		prr.rcvd.Inc()
+		prr.rtt.IncBy(metrics.NewInt(20000))
+		resultsChan <- prr
+	}
+	time.Sleep(3 * time.Second)
+
+	for i := 0; i < len(dataChan); i++ {
+		em := <-dataChan
+		var foundTarget bool
+		for _, target := range targets {
+			if em.Label("dst") == target {
+				foundTarget = true
+				break
+			}
+		}
+		if !foundTarget {
+			t.Error("didn't get expected target label in the event metric")
+		}
+		expectedValues := map[string]int64{
+			"sent": 1,
+			"rcvd": 1,
+			"rtt":  20000,
+		}
+		for key, eVal := range expectedValues {
+			val := em.Metric(key).(metrics.NumValue).Int64()
+			if val != eVal {
+				t.Errorf("%s metric is not set correctly. Got: %d, Expected: %d", key, val, eVal)
+			}
+		}
+	}
+}

--- a/probes/dns/dns_test.go
+++ b/probes/dns/dns_test.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/cloudprober/logger"
+	"github.com/google/cloudprober/probes/common/statskeeper"
 	configpb "github.com/google/cloudprober/probes/dns/proto"
 	"github.com/google/cloudprober/probes/options"
-	"github.com/google/cloudprober/probes/probeutils"
 	"github.com/google/cloudprober/targets"
 	"github.com/google/cloudprober/validators"
 	validatorpb "github.com/google/cloudprober/validators/proto"
@@ -71,7 +71,7 @@ func runProbe(t *testing.T, testName string, p *Probe, total, success int64) {
 	p.client = new(mockClient)
 	p.targets = p.opts.Targets.List()
 
-	resultsChan := make(chan probeutils.ProbeResult, len(p.targets))
+	resultsChan := make(chan statskeeper.ProbeResult, len(p.targets))
 	p.runProbe(resultsChan)
 
 	// The resultsChan output iterates through p.targets in the same order.

--- a/probes/probeutils/probeutils.go
+++ b/probes/probeutils/probeutils.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017-2019 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,82 +20,9 @@ package probeutils
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"net"
-	"time"
-
-	"github.com/google/cloudprober/logger"
-	"github.com/google/cloudprober/metrics"
 )
-
-// ProbeResult represents results of a probe run.
-type ProbeResult interface {
-	// Metrics converts ProbeResult into a map of the metrics that is suitable for
-	// working with metrics.EventMetrics.
-	Metrics() *metrics.EventMetrics
-
-	// Target returns the target associated with the probe result.
-	Target() string
-}
-
-// StatsKeeper manages and outputs probe results.
-//
-// Typical StatsKeepr usage pattern is that the probes start a StatsKeeper
-// goroutine in the beginning. StatsKeeper goroutine manages access to the
-// per-target cumulative metrics. It listens on an input channel for probe
-// results and updates the metrics whenever a new probe result is obtained.
-// It exports aggregate probe statistics to the output channel, at intervals
-// controlled by a Ticker. These two operations are mutually exclusive. This
-// is the only goroutine that accesses the metrics. StatsKeeper runs
-// indefinitely, across multiple probe runs, and should not stop during normal
-// program execution.
-//
-// If we get a new result on resultsChan, update the probe statistics.
-// If we get a timer tick on doExport, export probe data for all targets.
-// If context is canceled, return.
-//
-// Note that StatsKeeper calls a function (targetsFunc) to get the list of the
-// targets for exporting results,  instead of getting a static list in the
-// arguments. We do that as the list of targets is usually dynamic and is
-// updated on a regular basis.
-func StatsKeeper(ctx context.Context, ptype, name string, exportInterval time.Duration, targetsFunc func() []string, resultsChan <-chan ProbeResult, dataChan chan<- *metrics.EventMetrics, logMetrics func(*metrics.EventMetrics), l *logger.Logger) {
-	targetMetrics := make(map[string]*metrics.EventMetrics)
-	exportTicker := time.NewTicker(exportInterval)
-	defer exportTicker.Stop()
-
-	for {
-		select {
-		case result := <-resultsChan:
-			// result is a ProbeResult
-			t := result.Target()
-			if targetMetrics[t] == nil {
-				targetMetrics[t] = result.Metrics()
-				continue
-			}
-			err := targetMetrics[t].Update(result.Metrics())
-			if err != nil {
-				l.Errorf("Error adding metrics from the probe result for the target: %s. Err: %v", t, err)
-			}
-		case ts := <-exportTicker.C:
-			for _, t := range targetsFunc() {
-				em := targetMetrics[t]
-				if em != nil {
-					em.AddLabel("ptype", ptype)
-					em.AddLabel("probe", name)
-					em.AddLabel("dst", t)
-					em.Timestamp = ts
-					if logMetrics != nil {
-						logMetrics(em)
-					}
-					dataChan <- em.Clone()
-				}
-			}
-		case <-ctx.Done():
-			return
-		}
-	}
-}
 
 // PatternPayload builds a payload that can be verified using VerifyPayloadPattern.
 // It repeats the pattern to fill the payload []byte slice. Last remaining

--- a/probes/udplistener/udplistener.go
+++ b/probes/udplistener/udplistener.go
@@ -48,8 +48,8 @@ import (
 	"github.com/google/cloudprober/logger"
 	"github.com/google/cloudprober/message"
 	"github.com/google/cloudprober/metrics"
+	"github.com/google/cloudprober/probes/common/statskeeper"
 	"github.com/google/cloudprober/probes/options"
-	"github.com/google/cloudprober/probes/probeutils"
 
 	configpb "github.com/google/cloudprober/probes/udplistener/proto"
 	udpsrv "github.com/google/cloudprober/servers/udp"
@@ -231,7 +231,7 @@ func (p *Probe) processMessage(buf []byte, rxTS time.Time, srcAddr *net.UDPAddr)
 }
 
 // outputResults writes results to the output channel.
-func (p *Probe) outputResults(expectedCt int64, stats chan<- probeutils.ProbeResult) {
+func (p *Probe) outputResults(expectedCt int64, stats chan<- statskeeper.ProbeResult) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	for _, r := range p.res {
@@ -244,7 +244,7 @@ func (p *Probe) outputResults(expectedCt int64, stats chan<- probeutils.ProbeRes
 	p.initProbeRunResults()
 }
 
-func (p *Probe) outputLoop(ctx context.Context, stats chan<- probeutils.ProbeResult) {
+func (p *Probe) outputLoop(ctx context.Context, stats chan<- statskeeper.ProbeResult) {
 	// Use a ticker to control stats output and error logging.
 	// ticker should be a multiple of interval between pkts (i.e., p.opts.Interval).
 	pktsPerExportInterval := int64(p.opts.StatsExportInterval / p.opts.Interval)
@@ -331,7 +331,7 @@ func (p *Probe) recvLoop(ctx context.Context, echoChan chan<- *echoMsg) {
 }
 
 // probeLoop starts the necessary threads and waits for them to exit.
-func (p *Probe) probeLoop(ctx context.Context, resultsChan chan<- probeutils.ProbeResult) {
+func (p *Probe) probeLoop(ctx context.Context, resultsChan chan<- statskeeper.ProbeResult) {
 	var wg sync.WaitGroup
 
 	// Output Loop for metrics
@@ -358,12 +358,12 @@ func (p *Probe) probeLoop(ctx context.Context, resultsChan chan<- probeutils.Pro
 
 // Start starts and runs the probe indefinitely.
 func (p *Probe) Start(ctx context.Context, dataChan chan *metrics.EventMetrics) {
-	resultsChan := make(chan probeutils.ProbeResult, len(p.targets))
+	resultsChan := make(chan statskeeper.ProbeResult, len(p.targets))
 	targetsFunc := func() []string {
 		return p.targets
 	}
 
-	go probeutils.StatsKeeper(ctx, "udp", p.name, p.opts.StatsExportInterval, targetsFunc, resultsChan, dataChan, p.opts.LogMetrics, p.l)
+	go statskeeper.StatsKeeper(ctx, "udp", p.name, p.opts, targetsFunc, resultsChan, dataChan)
 
 	// probeLoop runs forever and returns only when the probe has to exit.
 	// So, it is safe to cleanup (in the "Start" function) once probeLoop returns.

--- a/probes/udplistener/udplistener_test.go
+++ b/probes/udplistener/udplistener_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/google/cloudprober/logger"
 	"github.com/google/cloudprober/message"
 	"github.com/google/cloudprober/metrics"
+	"github.com/google/cloudprober/probes/common/statskeeper"
 	"github.com/google/cloudprober/probes/options"
-	"github.com/google/cloudprober/probes/probeutils"
 	"github.com/google/cloudprober/sysvars"
 	"github.com/google/cloudprober/targets"
 
@@ -144,7 +144,7 @@ func sendPktsAndCollectReplies(ctx context.Context, t *testing.T, srvPort int, i
 	return rxSeq
 }
 
-func runProbe(ctx context.Context, t *testing.T, inp *inputState) ([]int, chan probeutils.ProbeResult, *probeRunResult, probeErr) {
+func runProbe(ctx context.Context, t *testing.T, inp *inputState) ([]int, chan statskeeper.ProbeResult, *probeRunResult, probeErr) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -178,7 +178,7 @@ func runProbe(ctx context.Context, t *testing.T, inp *inputState) ([]int, chan p
 	port := p.conn.LocalAddr().(*net.UDPAddr).Port
 
 	p.targets = p.opts.Targets.List()
-	resultsChan := make(chan probeutils.ProbeResult, 10)
+	resultsChan := make(chan statskeeper.ProbeResult, 10)
 	go p.probeLoop(ctx, resultsChan)
 	time.Sleep(interval) // Wait for echo loop to be active.
 
@@ -320,7 +320,7 @@ func TestResultsChan(t *testing.T) {
 	}
 	_, resChan, _, _ := runProbe(ctx, t, inp)
 
-	var res []probeutils.ProbeResult
+	var res []statskeeper.ProbeResult
 readResChan:
 	for {
 		select {


### PR DESCRIPTION
= Statskeeper is quite specific to be in a general utils package.
= This will allow statskeeper to access the probes/options package (package/options in turn depends on some methods in probeutils).

PiperOrigin-RevId: 278639167