### PR TITLE
Fix error message when failing to parse upper bound

### DIFF
--- a/validators/http/http.go
+++ b/validators/http/http.go
@@ -66,7 +66,7 @@ func parseNumRange(s string) (*numRange, error) {
 
 	upper, err := strconv.ParseInt(fields[1], 10, 32)
 	if err != nil {
-		return nil, fmt.Errorf("got error while parsing the range's lower bound (%s): %v", fields[1], err)
+		return nil, fmt.Errorf("got error while parsing the range's upper bound (%s): %v", fields[1], err)
 	}
 
 	if upper < lower {


### PR DESCRIPTION
The same error message `got error while parsing the range's lower bound` is being used even when the upper bound raises an error.

This PR just changes the error message to reflect that the upper bound has an error instead.