### PR TITLE
Refactor validators to make extending them easier.

### DIFF
--- a/probes/dns/dns.go
+++ b/probes/dns/dns.go
@@ -187,7 +187,7 @@ func (p *Probe) validateResponse(resp *dns.Msg, target string, result *probeRunR
 		}
 		respBytes := []byte(strings.Join(answers, "\n"))
 
-		failedValidations := validators.RunValidators(p.opts.Validators, nil, respBytes, result.validationFailure, p.l)
+		failedValidations := validators.RunValidators(p.opts.Validators, &validators.Input{ResponseBody: respBytes}, result.validationFailure, p.l)
 		if len(failedValidations) > 0 {
 			p.l.Debugf("Target(%s): validators %v failed. Resp: %v", target, failedValidations, answers)
 			return false

--- a/probes/external/external.go
+++ b/probes/external/external.go
@@ -372,7 +372,7 @@ type probeStatus struct {
 
 func (p *Probe) processProbeResult(ps *probeStatus, result *result) {
 	if ps.success && p.opts.Validators != nil {
-		failedValidations := validators.RunValidators(p.opts.Validators, nil, []byte(ps.payload), result.validationFailure, p.l)
+		failedValidations := validators.RunValidators(p.opts.Validators, &validators.Input{ResponseBody: []byte(ps.payload)}, result.validationFailure, p.l)
 
 		// If any validation failed, log and set success to false.
 		if len(failedValidations) > 0 {

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -210,7 +210,7 @@ func (p *Probe) doHTTPRequest(req *http.Request, result *probeResult, resultMu *
 	result.respCodes.IncKey(strconv.FormatInt(int64(resp.StatusCode), 10))
 
 	if p.opts.Validators != nil {
-		failedValidations := validators.RunValidators(p.opts.Validators, resp, respBody, result.validationFailure, p.l)
+		failedValidations := validators.RunValidators(p.opts.Validators, &validators.Input{Response: resp, ResponseBody: respBody}, result.validationFailure, p.l)
 
 		// If any validation failed, return now, leaving the success and latency
 		// counters unchanged.

--- a/probes/options/options.go
+++ b/probes/options/options.go
@@ -73,7 +73,7 @@ type Options struct {
 	ProbeConf           interface{} // Probe-type specific config
 	LatencyDist         *metrics.Distribution
 	LatencyUnit         time.Duration
-	Validators          []*validators.ValidatorWithName
+	Validators          []*validators.Validator
 	SourceIP            net.IP
 	IPVersion           int
 	StatsExportInterval time.Duration

--- a/validators/integrity/integrity.go
+++ b/validators/integrity/integrity.go
@@ -56,7 +56,7 @@ func (v *Validator) Init(config interface{}, l *logger.Logger) error {
 
 // Validate validates the provided responseBody for data integrity errors, for
 // example, data corruption.
-func (v *Validator) Validate(unusedResponseObj interface{}, responseBody []byte) (bool, error) {
+func (v *Validator) Validate(responseBody []byte) (bool, error) {
 	pattern := v.pattern
 	if len(pattern) == 0 {
 		if len(responseBody) < int(v.patternNumBytes) {

--- a/validators/integrity/integrity_test.go
+++ b/validators/integrity/integrity_test.go
@@ -64,7 +64,7 @@ func verifyValidate(t *testing.T, v Validator, testPattern string) {
 	}
 
 	for i, r := range rows {
-		result, err := v.Validate(nil, r.respBody)
+		result, err := v.Validate(r.respBody)
 		if (err != nil) != r.wantErr {
 			t.Errorf("v.Validate(nil, %s), row #%d: err=%v, expectedError(bool)=%v", string(r.respBody), i, err, r.wantErr)
 		}

--- a/validators/regex/regex.go
+++ b/validators/regex/regex.go
@@ -54,6 +54,6 @@ func (v *Validator) Init(config interface{}, l *logger.Logger) error {
 
 // Validate the provided responseBody and return true if responseBody matches
 // the configured regex.
-func (v *Validator) Validate(unusedResponseObj interface{}, responseBody []byte) (bool, error) {
+func (v *Validator) Validate(responseBody []byte) (bool, error) {
 	return v.r.Match(responseBody), nil
 }

--- a/validators/regex/regex_test.go
+++ b/validators/regex/regex_test.go
@@ -47,7 +47,7 @@ func verifyValidate(t *testing.T, respBody []byte, regexStr string, expected boo
 		t.Errorf("v.Init(%s, l): got error: %v", regexStr, err)
 	}
 
-	result, err := v.Validate(nil, respBody)
+	result, err := v.Validate(respBody)
 	if err != nil {
 		t.Errorf("v.Validate(nil, %s): got error: %v", string(respBody), err)
 	}

--- a/validators/validators_test.go
+++ b/validators/validators_test.go
@@ -36,20 +36,20 @@ func (tv *testValidator) Validate(responseObject interface{}, responseBody []byt
 	return false, nil
 }
 
-var testValidators = []*ValidatorWithName{
+var testValidators = []*Validator{
 	{
-		Name:      "test-v1",
-		Validator: &testValidator{true},
+		Name:     "test-v1",
+		Validate: func(input *Input) (bool, error) { return true, nil },
 	},
 	{
-		Name:      "test-v2",
-		Validator: &testValidator{false},
+		Name:     "test-v2",
+		Validate: func(input *Input) (bool, error) { return false, nil },
 	},
 }
 
 func TestRunValidators(t *testing.T) {
 	vfMap := ValidationFailureMap(testValidators)
-	failures := RunValidators(testValidators, nil, nil, vfMap, nil)
+	failures := RunValidators(testValidators, &Input{}, vfMap, nil)
 
 	if vfMap.GetKey("test-v1").Int64() != 0 {
 		t.Error("Got unexpected test-v1 validation failure.")
@@ -59,7 +59,7 @@ func TestRunValidators(t *testing.T) {
 		t.Errorf("Didn't get expected test-v2 validation failure.")
 	}
 
-	if len(failures) != 1 && failures[0] != "test-v2" {
+	if !reflect.DeepEqual(failures, []string{"test-v2"}) {
 		t.Errorf("Didn't get expected validation failures. Expected: {\"test-v2\"}, Got: %v", failures)
 	}
 }


### PR DESCRIPTION
= Instead of making validators.Validator an interface{} that various types of validators implement, make it a concrete struct with a function field Validate() that is implemented differently based on the validator type in the config. This has a few advantages:

  ++ Individual validator types don't have to keep up with the interface changes as we extend the validators over time. For example, RegexValidator's validator can take just one input that it cares about (responseBody), instead of taking everything and then ignoring.
  ++ Use of Validator (interface{}) and ValidatorWithName (struct) was a little confusing. Making Validator a struct does away with that need.
  ++ Validators are called very often (per probe per target) and interface->actual object resolution can be slightly expensive. On the other hand, there are very few instances of the Validator objects, making the cost of function copy negligible.

= Use validators.Input{} for input to the Validate function instead of specifying individual items like response and responseBody. This will allow us to add more input type, for example latency, for validation without requiring to change function signatures everywhere.

PiperOrigin-RevId: 283680552