### PR TITLE
Cloudprober logging improvements.

### DIFF
--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,0 +1,36 @@
+package logger
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestEnvVarSet(t *testing.T) {
+	varName := "TEST_VAR"
+
+	testRows := []struct {
+		v        string
+		expected bool
+	}{
+		{"1", true},
+		{"yes", true},
+		{"not_set", false},
+		{"no", false},
+		{"false", false},
+	}
+
+	for _, row := range testRows {
+		t.Run(fmt.Sprintf("Val: %s, should be set: %v", row.v, row.expected), func(t *testing.T) {
+			os.Unsetenv(varName)
+			if row.v != "not_set" {
+				os.Setenv(varName, row.v)
+			}
+
+			got := envVarSet(varName)
+			if got != row.expected {
+				t.Errorf("Variable set: got=%v, expected=%v", got, row.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
= Make it possible to enable debug log by log name (--debug_logname_regex=<logNameRegex>).
= Add a flag do disable cloud logging (--disable_cloud_logging).
= Provide a way to enable debug log and disable cloud through environment variables: CLOUDPROBER_DEBUG_LOG, CLOUDPROBER_DISABLE_CLOUD_LOGGING.

Example run:
./cloudprober --config_file=/tmp/cloudprober.cfg --debug_log_regex=.*gcs.* \
  --debug_logname_regex=.*gcs.* --logtostderr

To disable cloud logging for all subsystems:
./cloudprober --config_file=/tmp/cloudprober.cfg --disable_cloud_logging

Fix #322.

PiperOrigin-RevId: 285027647