### PR TITLE
HTTP probe: For "Host" header set request's Host field.

### DIFF
--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -75,6 +75,10 @@ func (p *Probe) httpRequestForTarget(target endpoint.Endpoint) *http.Request {
 	req.Host = target.Name
 
 	for _, header := range p.c.GetHeaders() {
+		if header.GetName() == "Host" {
+			req.Host = header.GetValue()
+			continue
+		}
 		req.Header.Set(header.GetName(), header.GetValue())
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/google/cloudprober/issues/331
Background: https://github.com/golang/go/issues/7682
PiperOrigin-RevId: 285370151