### PR TITLE
K8s RDS: Return an error if API response status code is not 200.

### DIFF
--- a/rds/kubernetes/client.go
+++ b/rds/kubernetes/client.go
@@ -65,6 +65,10 @@ func (c *client) getURL(url string) ([]byte, error) {
 		return nil, err
 	}
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP response status code: %d, status: %s", resp.StatusCode, resp.Status)
+	}
+
 	return ioutil.ReadAll(resp.Body)
 }
 


### PR DESCRIPTION
PiperOrigin-RevId: 286020060