### PR TITLE
When updating a metric value for a distribution always return after parsing the distribution value.

### DIFF
--- a/metrics/payload/payload.go
+++ b/metrics/payload/payload.go
@@ -90,6 +90,7 @@ func updateMetricValue(mv metrics.Value, val string) error {
 		if err := processDistValue(mVal, val); err != nil {
 			return fmt.Errorf("error parsing distribution value (%s): %v", val, err)
 		}
+		return nil
 	}
 
 	v, err := metrics.ParseValueFromString(val)


### PR DESCRIPTION
When updating a metric value for a distribution always return after parsing the distribution value.

For formats that are sending all the values as a list current behavior will update the value but will log an error when trying to parse it as value. For distribution values with "dist" is a double counting bug (every parsed value is added twice).

PiperOrigin-RevId: 286751909