### PR TITLE
Fix docker build in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,11 @@ docker_build: $(BINARY) ca-certificates.crt Dockerfile
 		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg VCS_REF=$(GIT_COMMIT) \
-		-t $(DOCKER_IMAGE):$(DOCKER_VERSION) .
+		-t $(DOCKER_IMAGE)  .
+	docker tag $(DOCKER_IMAGE) $(DOCKER_IMAGE):$(DOCKER_VERSION)
 
 docker_push:
-	docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+	docker login -u "${DOCKER_USER}" -p "${DOCKER_PASS}"
 	docker push $(DOCKER_IMAGE):$(VERSION)
 	docker push $(DOCKER_IMAGE):latest
 


### PR DESCRIPTION
Build an image with the latest version and then tag it with the tag based docker version.