### PR TITLE
rds/gcp: Make project optional in resource path and some other improvements.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go v1.25.37
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
-	github.com/golang/protobuf v1.3.2
+	github.com/golang/protobuf v1.3.3
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/hoisie/redis v0.0.0-20160730154456-b5c6e81454e0

--- a/go.mod
+++ b/go.mod
@@ -28,5 +28,5 @@ require (
 	google.golang.org/api v0.13.0
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/genproto v0.0.0-20191115221424-83cc0476cb11
-	google.golang.org/grpc v1.25.1
+	google.golang.org/grpc v1.27.0
 )

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
+github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,7 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
+github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
@@ -216,6 +217,8 @@ google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ij
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1 h1:wdKvqQk7IttEw92GoRyKG2IDrUIpgpj6H6m81yfeMW0=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
+google.golang.org/grpc v1.27.0 h1:rRYRFMVgRv6E0D70Skyfsr28tDXIuuPZyWGMPdMcnXg=
+google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/prober/proto/service.pb.go
+++ b/prober/proto/service.pb.go
@@ -322,11 +322,11 @@ var fileDescriptor_8f3b8b8b1a64dfb2 = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion4
+const _ = grpc.SupportPackageIsVersion6
 
 // CloudproberClient is the client API for Cloudprober service.
 //
@@ -342,10 +342,10 @@ type CloudproberClient interface {
 }
 
 type cloudproberClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewCloudproberClient(cc *grpc.ClientConn) CloudproberClient {
+func NewCloudproberClient(cc grpc.ClientConnInterface) CloudproberClient {
 	return &cloudproberClient{cc}
 }
 

--- a/rds/gcp/gce_instances_test.go
+++ b/rds/gcp/gce_instances_test.go
@@ -237,7 +237,10 @@ func testListResources(t *testing.T, f []*pb.Filter, ipConfig *pb.IPConfig, gil 
 		filters = append(filters, f...)
 	}
 
-	resources, err := gil.listResources(filters, ipConfig)
+	resources, err := gil.listResources(&pb.ListResourcesRequest{
+		Filter:   filters,
+		IpConfig: ipConfig,
+	})
 
 	if err != nil {
 		if !expectError {

--- a/rds/gcp/gcp.go
+++ b/rds/gcp/gcp.go
@@ -16,16 +16,17 @@
 Package gcp implements a GCP (Google Compute Platform) resources provider for
 ResourceDiscovery server.
 
-It currently supports following GCP resources:
-		GCE Instances (gce_instance)
+See ResourceTypes variable for the list of supported resource types.
 
 GCP provider is configured through a protobuf based config file
 (proto/config.proto). Example config:
-{
-  project_id: 'test-project-1'
-  project_id: 'test-project-2'
-  gce_instances {}
-}
+
+	{
+		project_id: 'test-project-1'
+		project_id: 'test-project-2'
+		gce_instances {}
+	}
+
 */
 package gcp
 
@@ -47,6 +48,8 @@ import (
 const DefaultProviderID = "gcp"
 
 // ResourceTypes declares resource types supported by the GCP provider.
+// Note that "rtc_variables" resource type is deprecated now and will soon be
+// removed.
 var ResourceTypes = struct {
 	GCEInstances, RTCVariables, PubsubMessages string
 }{
@@ -55,79 +58,59 @@ var ResourceTypes = struct {
 	"pubsub_messages",
 }
 
+var resourcePathTmpl = "<resource_type>[/<project-id>]"
+
+type lister interface {
+	listResources(req *pb.ListResourcesRequest) ([]*pb.Resource, error)
+}
+
 // Provider implements a GCP provider for a ResourceDiscovery server.
 type Provider struct {
-	gceInstances map[string]*gceInstancesLister
-	rtcVariables map[string]*rtcVariablesLister
-	pubsubMsgs   map[string]*pubsubMsgsLister
+	localProject string
+
+	listers map[string]map[string]lister
 }
 
 // ListResources returns the list of resources from the cache.
 func (p *Provider) ListResources(req *pb.ListResourcesRequest) (*pb.ListResourcesResponse, error) {
 	tok := strings.SplitN(req.GetResourcePath(), "/", 2)
-	if len(tok) != 2 {
-		return nil, fmt.Errorf("%s is not a valid GCP resource path", req.GetResourcePath())
-	}
 	resType := tok[0]
 	project := tok[1]
 
-	switch resType {
-	case ResourceTypes.GCEInstances:
-		gil := p.gceInstances[project]
-		if gil == nil {
-			return nil, fmt.Errorf("gcp: GCE instances lister for the project %s not found", project)
+	var projectListers map[string]lister
+
+	if project == "" && len(p.listers) == 1 {
+		for _, pL := range p.listers {
+			projectListers = pL
 		}
-		resources, err := gil.listResources(req.GetFilter(), req.GetIpConfig())
-		return &pb.ListResourcesResponse{Resources: resources}, err
-	case ResourceTypes.RTCVariables:
-		rvl := p.rtcVariables[project]
-		if rvl == nil {
-			return nil, fmt.Errorf("gcp: RTC variables lister for the project %s not found", project)
+	} else {
+		projectListers = p.listers[project]
+		if projectListers == nil {
+			return nil, fmt.Errorf("no lister found for the project: %s", project)
 		}
-		resources, err := rvl.listResources(req.GetFilter())
-		return &pb.ListResourcesResponse{Resources: resources}, err
-	case ResourceTypes.PubsubMessages:
-		lister := p.pubsubMsgs[project]
-		if lister == nil {
-			return nil, fmt.Errorf("gcp: Pub/Sub messages lister for the project %s not found", project)
-		}
-		resources, err := lister.listResources(req.GetFilter())
-		return &pb.ListResourcesResponse{Resources: resources}, err
-	default:
-		return nil, fmt.Errorf("gcp: unsupported resource type: %s", resType)
 	}
+
+	lr := projectListers[resType]
+	if lr == nil {
+		return nil, fmt.Errorf("unknown resource type: %s", resType)
+	}
+
+	resources, err := lr.listResources(req)
+	return &pb.ListResourcesResponse{Resources: resources}, err
 }
 
-// New creates a GCP provider for RDS server, based on the provided config.
-func New(c *configpb.ProviderConfig, l *logger.Logger) (*Provider, error) {
-	projects := c.GetProject()
-	if len(projects) == 0 {
-		if !metadata.OnGCE() {
-			return nil, errors.New("rds.gcp.New(): project is required for GCP resources when not running on GCE")
-		}
-		proj, err := metadata.ProjectID()
-		if err != nil {
-			return nil, fmt.Errorf("rds.gcp.New(): error getting local project ID: %v", err)
-		}
-		projects = append(projects, proj)
-	}
-
-	p := &Provider{
-		gceInstances: make(map[string]*gceInstancesLister),
-		rtcVariables: make(map[string]*rtcVariablesLister),
-		pubsubMsgs:   make(map[string]*pubsubMsgsLister),
-	}
+func initGCPProject(project string, c *configpb.ProviderConfig, l *logger.Logger) (map[string]lister, error) {
+	projectLister := make(map[string]lister)
 
 	// Enable GCE instances lister if configured.
 	if c.GetGceInstances() != nil {
-		for _, project := range projects {
-			gil, err := newGCEInstancesLister(project, c.GetApiVersion(), c.GetGceInstances(), l)
-			if err != nil {
-				return nil, err
-			}
-			p.gceInstances[project] = gil
+		lr, err := newGCEInstancesLister(project, c.GetApiVersion(), c.GetGceInstances(), l)
+		if err != nil {
+			return nil, err
 		}
+		projectLister[ResourceTypes.GCEInstances] = lr
 	}
+
 	// Enable regional forwarding lister if configured.
 	// TODO(manugarg): implement this.
 	if c.GetRegionalForwardingRules() != nil {
@@ -136,25 +119,53 @@ func New(c *configpb.ProviderConfig, l *logger.Logger) (*Provider, error) {
 
 	// Enable RTC variables lister if configured.
 	if c.GetPubsubMessages() != nil {
-		for _, project := range projects {
-			lister, err := newPubSubMsgsLister(project, c.GetPubsubMessages(), l)
-			if err != nil {
-				return nil, err
-			}
-			p.pubsubMsgs[project] = lister
+		lr, err := newPubSubMsgsLister(project, c.GetPubsubMessages(), l)
+		if err != nil {
+			return nil, err
 		}
+		projectLister[ResourceTypes.PubsubMessages] = lr
 	}
 
 	// Enable RTC variables lister if configured.
 	if c.GetRtcVariables() != nil {
-		for _, project := range projects {
-			rvl, err := newRTCVariablesLister(project, c.GetApiVersion(), c.GetRtcVariables(), l)
-			if err != nil {
-				return nil, err
-			}
-			p.rtcVariables[project] = rvl
+		lr, err := newRTCVariablesLister(project, c.GetApiVersion(), c.GetRtcVariables(), l)
+		if err != nil {
+			return nil, err
 		}
+		projectLister[ResourceTypes.RTCVariables] = lr
 	}
+
+	return projectLister, nil
+}
+
+// New creates a GCP provider for RDS server, based on the provided config.
+func New(c *configpb.ProviderConfig, l *logger.Logger) (*Provider, error) {
+	projects := c.GetProject()
+	if len(projects) == 0 {
+		if !metadata.OnGCE() {
+			return nil, errors.New("rds.gcp.New(): project not configured and not running on GCE")
+		}
+
+		project, err := metadata.ProjectID()
+		if err != nil {
+			return nil, fmt.Errorf("rds.gcp.New(): error getting the local project ID on GCE: %v", err)
+		}
+
+		projects = append(projects, project)
+	}
+
+	p := &Provider{
+		listers: make(map[string]map[string]lister),
+	}
+
+	for _, project := range projects {
+		projectLister, err := initGCPProject(project, c, l)
+		if err != nil {
+			return nil, err
+		}
+		p.listers[project] = projectLister
+	}
+
 	return p, nil
 }
 

--- a/rds/gcp/pubsub.go
+++ b/rds/gcp/pubsub.go
@@ -30,6 +30,26 @@ import (
 	"google.golang.org/api/option"
 )
 
+/*
+PubSubFilters defines filters supported by the pubsub_messages resource type.
+ Example:
+ filter {
+	 key: "subscription"
+	 value: "sub1.*"
+ }
+ filter {
+	 key: "updated_within"
+	 value: "5m"
+ }
+*/
+var PubSubFilters = struct {
+	RegexFilterKeys    []string
+	FreshnessFilterKey string
+}{
+	[]string{"subscription"},
+	"updated_within",
+}
+
 // pubsubMsgsLister is a PubSub Messages lister. It implements a cache,
 // that's populated at a regular interval by making the GCP API calls.
 // Listing actually only returns the current contents of that cache.
@@ -48,8 +68,8 @@ type pubsubMsgsLister struct {
 
 // listResources returns the list of resource records, where each record
 // consists of a PubSub message name.
-func (lister *pubsubMsgsLister) listResources(filters []*pb.Filter) ([]*pb.Resource, error) {
-	allFilters, err := filter.ParseFilters(filters, []string{"subscription"}, "updated_within")
+func (lister *pubsubMsgsLister) listResources(req *pb.ListResourcesRequest) ([]*pb.Resource, error) {
+	allFilters, err := filter.ParseFilters(req.GetFilter(), PubSubFilters.RegexFilterKeys, PubSubFilters.FreshnessFilterKey)
 	if err != nil {
 		return nil, err
 	}

--- a/rds/gcp/pubsub_test.go
+++ b/rds/gcp/pubsub_test.go
@@ -44,14 +44,16 @@ func TestListMessages(t *testing.T) {
 
 	// Subscription s1, updated within 5m
 	want = []string{"m2"}
-	resources, err = lister.listResources([]*pb.Filter{
-		&pb.Filter{
-			Key:   proto.String("subscription"),
-			Value: proto.String("s1"),
-		},
-		&pb.Filter{
-			Key:   proto.String("updated_within"),
-			Value: proto.String("5m"),
+	resources, err = lister.listResources(&pb.ListResourcesRequest{
+		Filter: []*pb.Filter{
+			&pb.Filter{
+				Key:   proto.String("subscription"),
+				Value: proto.String("s1"),
+			},
+			&pb.Filter{
+				Key:   proto.String("updated_within"),
+				Value: proto.String("5m"),
+			},
 		},
 	})
 
@@ -62,10 +64,12 @@ func TestListMessages(t *testing.T) {
 
 	// Subscription s1 and s2
 	want = []string{"m1", "m2", "m3"}
-	resources, _ = lister.listResources([]*pb.Filter{
-		&pb.Filter{
-			Key:   proto.String("subscription"),
-			Value: proto.String("s"),
+	resources, _ = lister.listResources(&pb.ListResourcesRequest{
+		Filter: []*pb.Filter{
+			&pb.Filter{
+				Key:   proto.String("subscription"),
+				Value: proto.String("s"),
+			},
 		},
 	})
 

--- a/rds/gcp/rtc_variables.go
+++ b/rds/gcp/rtc_variables.go
@@ -55,10 +55,10 @@ type rtcVariablesLister struct {
 
 // listResources returns the list of resource records, where each record
 // consists of a RTC variable name.
-func (rvl *rtcVariablesLister) listResources(filters []*pb.Filter) ([]*pb.Resource, error) {
+func (rvl *rtcVariablesLister) listResources(req *pb.ListResourcesRequest) ([]*pb.Resource, error) {
 	var resources []*pb.Resource
 
-	allFilters, err := filter.ParseFilters(filters, []string{"config_name"}, "updated_within")
+	allFilters, err := filter.ParseFilters(req.GetFilter(), []string{"config_name"}, "updated_within")
 	if err != nil {
 		return nil, err
 	}

--- a/rds/gcp/rtc_variables_test.go
+++ b/rds/gcp/rtc_variables_test.go
@@ -101,14 +101,16 @@ func TestListRTCVars(t *testing.T) {
 
 	// Config c1, updated within 5m
 	want = []string{"v2"}
-	resources, err = rvl.listResources([]*pb.Filter{
-		&pb.Filter{
-			Key:   proto.String("config_name"),
-			Value: proto.String("c1"),
-		},
-		&pb.Filter{
-			Key:   proto.String("updated_within"),
-			Value: proto.String("5m"),
+	resources, err = rvl.listResources(&pb.ListResourcesRequest{
+		Filter: []*pb.Filter{
+			&pb.Filter{
+				Key:   proto.String("config_name"),
+				Value: proto.String("c1"),
+			},
+			&pb.Filter{
+				Key:   proto.String("updated_within"),
+				Value: proto.String("5m"),
+			},
 		},
 	})
 
@@ -119,10 +121,12 @@ func TestListRTCVars(t *testing.T) {
 
 	// Config c1 and c2
 	want = []string{"v1", "v2", "v3"}
-	resources, _ = rvl.listResources([]*pb.Filter{
-		&pb.Filter{
-			Key:   proto.String("config_name"),
-			Value: proto.String("c"),
+	resources, _ = rvl.listResources(&pb.ListResourcesRequest{
+		Filter: []*pb.Filter{
+			&pb.Filter{
+				Key:   proto.String("config_name"),
+				Value: proto.String("c"),
+			},
 		},
 	})
 

--- a/rds/proto/rds.pb.go
+++ b/rds/proto/rds.pb.go
@@ -417,11 +417,11 @@ var fileDescriptor_76052690f78f622a = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion4
+const _ = grpc.SupportPackageIsVersion6
 
 // ResourceDiscoveryClient is the client API for ResourceDiscovery service.
 //
@@ -433,10 +433,10 @@ type ResourceDiscoveryClient interface {
 }
 
 type resourceDiscoveryClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewResourceDiscoveryClient(cc *grpc.ClientConn) ResourceDiscoveryClient {
+func NewResourceDiscoveryClient(cc grpc.ClientConnInterface) ResourceDiscoveryClient {
 	return &resourceDiscoveryClient{cc}
 }
 

--- a/servers/grpc/proto/grpcservice.pb.go
+++ b/servers/grpc/proto/grpcservice.pb.go
@@ -338,11 +338,11 @@ var fileDescriptor_3ba4b0e85eb4edfe = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion4
+const _ = grpc.SupportPackageIsVersion6
 
 // ProberClient is the client API for Prober service.
 //
@@ -359,10 +359,10 @@ type ProberClient interface {
 }
 
 type proberClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewProberClient(cc *grpc.ClientConn) ProberClient {
+func NewProberClient(cc grpc.ClientConnInterface) ProberClient {
 	return &proberClient{cc}
 }
 


### PR DESCRIPTION
rds/gcp: Make project optional in resource path and some other improvements.

= If project is not provided and only one project is configured in the provider, we use that project.

= Make GCP resource-type implementations have uniform interfaces.

PiperOrigin-RevId: 291809215