### PR TITLE
Replace label_<key> with labels_<key> for label variables.

### DIFF
--- a/sysvars/sysvars_gce.go
+++ b/sysvars/sysvars_gce.go
@@ -87,9 +87,9 @@ func gceVars(vars map[string]string) error {
 	}
 
 	for k, v := range labels {
-		// Adds GCE labels to the dictionary with a 'label_' prefix so they can be
+		// Adds GCE labels to the dictionary with a 'labels_' prefix so they can be
 		// referenced in the cfg file.
-		vars["label_"+k] = v
+		vars["labels_"+k] = v
 
 	}
 	return nil


### PR DESCRIPTION
This is what we use everywhere else:
https://github.com/google/cloudprober/blob/921faa63ccf2773a897b76718569aecf2cf4e3d4/probes/options/options.go#L225
https://github.com/google/cloudprober/blob/921faa63ccf2773a897b76718569aecf2cf4e3d4/rds/server/filter/utils.go#L61

PiperOrigin-RevId: 304865716