### PR TITLE
Cleanup targets interfaces.

### DIFF
--- a/examples/extensions/myprober/myprobe/myprobe.go
+++ b/examples/extensions/myprober/myprobe/myprobe.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/cloudprober/logger"
 	"github.com/google/cloudprober/metrics"
 	"github.com/google/cloudprober/probes/options"
+	"github.com/google/cloudprober/targets/endpoint"
 	"github.com/hoisie/redis"
 )
 
@@ -52,7 +53,7 @@ func (p *Probe) Start(ctx context.Context, dataChan chan *metrics.EventMetrics) 
 			for _, em := range p.res {
 				dataChan <- em
 			}
-			p.targets = p.opts.Targets.List()
+			p.targets = endpoint.NamesFromEndpoints(p.opts.Targets.ListEndpoints())
 			p.initProbeMetrics()
 			probeCtx, cancelFunc := context.WithDeadline(ctx, time.Now().Add(p.opts.Timeout))
 			p.runProbe(probeCtx)
@@ -107,7 +108,7 @@ func (p *Probe) runProbeForTarget(ctx context.Context, target string) error {
 
 // runProbe runs probe for all targets and update EventMetrics.
 func (p *Probe) runProbe(ctx context.Context) {
-	p.targets = p.opts.Targets.List()
+	p.targets = endpoint.NamesFromEndpoints(p.opts.Targets.ListEndpoints())
 
 	var wg sync.WaitGroup
 	for _, target := range p.targets {

--- a/rds/client/client.go
+++ b/rds/client/client.go
@@ -98,13 +98,6 @@ func (client *Client) updateState(response *pb.ListResourcesResponse) {
 	}
 }
 
-// List returns the list of resource names.
-func (client *Client) List() []string {
-	client.mu.Lock()
-	defer client.mu.Unlock()
-	return append([]string{}, client.names...)
-}
-
 // ListEndpoints returns the list of resources.
 func (client *Client) ListEndpoints() []endpoint.Endpoint {
 	client.mu.Lock()

--- a/rds/client/client_test.go
+++ b/rds/client/client_test.go
@@ -90,14 +90,6 @@ func TestListAndResolve(t *testing.T) {
 		}
 		client.refreshState(time.Second)
 
-		// Test List()
-		list := client.List()
-		for i, res := range testResources {
-			if res.GetName() != list[i] {
-				t.Errorf("Didn't get expected resource. Got: %s, Want: %s", list[i], res.GetName())
-			}
-		}
-
 		// Test ListEndpoint()
 		epList := client.ListEndpoints()
 		for i, res := range testResources {

--- a/rds/client/cmd/client.go
+++ b/rds/client/cmd/client.go
@@ -82,9 +82,9 @@ func main() {
 	for {
 		fmt.Printf("%s\n", time.Now())
 
-		for _, name := range tgts.List() {
-			ip, _ := tgts.Resolve(name, 4)
-			fmt.Printf("%s\t%s\n", name, ip.String())
+		for _, ep := range tgts.ListEndpoints() {
+			ip, _ := tgts.Resolve(ep.Name, 4)
+			fmt.Printf("%s\t%s\n", ep.Name, ip.String())
 		}
 		time.Sleep(5 * time.Second)
 	}

--- a/targets/endpoint/endpoint.go
+++ b/targets/endpoint/endpoint.go
@@ -34,3 +34,13 @@ func EndpointsFromNames(names []string) []Endpoint {
 	}
 	return result
 }
+
+// NamesFromEndpoints is convenience function to build a list of names
+// from endpoints.
+func NamesFromEndpoints(endpoints []Endpoint) []string {
+	result := make([]string, len(endpoints))
+	for i, ep := range endpoints {
+		result[i] = ep.Name
+	}
+	return result
+}

--- a/targets/gce/forwarding_rules.go
+++ b/targets/gce/forwarding_rules.go
@@ -24,6 +24,7 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	"github.com/google/cloudprober/logger"
+	"github.com/google/cloudprober/targets/endpoint"
 	configpb "github.com/google/cloudprober/targets/gce/proto"
 	compute "google.golang.org/api/compute/v1"
 )
@@ -65,8 +66,8 @@ type forwardingRules struct {
 // List produces a list of all the forwarding rules. The list is similar to
 // "gcloud compute forwarding-rules list", but with a cache layer reducing the
 // number of actual API calls made.
-func (frp *forwardingRules) List() []string {
-	return frp.names
+func (frp *forwardingRules) ListEndpoints() []endpoint.Endpoint {
+	return endpoint.EndpointsFromNames(frp.names)
 }
 
 // Resolve returns the IP address associated with the forwarding
@@ -191,7 +192,7 @@ func newForwardingRules(project string, opts *configpb.GlobalOptions, frpb *conf
 
 		go func() {
 			globalForwardingRules.expand()
-			for _ = range time.Tick(reEvalInterval) {
+			for range time.Tick(reEvalInterval) {
 				globalForwardingRules.expand()
 			}
 		}()

--- a/targets/gce/gce.go
+++ b/targets/gce/gce.go
@@ -77,8 +77,8 @@ var global struct {
 // Targets interface is redefined here (originally defined in targets.go) to
 // allow returning private gceResources.
 type Targets interface {
-	// List produces list of targets.
-	List() []string
+	// ListEndpoints produces list of targets.
+	ListEndpoints() []endpoint.Endpoint
 	// Resolve, given a target name and IP Version will return the IP address for
 	// that target.
 	Resolve(name string, ipVer int) (net.IP, error)
@@ -162,15 +162,6 @@ func (gr *gceResources) initClients(projects []string) error {
 	}
 
 	return nil
-}
-
-// List returns the list of target names.
-func (gr *gceResources) List() []string {
-	var names []string
-	for _, client := range gr.clients {
-		names = append(names, client.List()...)
-	}
-	return names
 }
 
 // ListEndpoints returns the list of GCE endpoints.

--- a/targets/gce/gce_test.go
+++ b/targets/gce/gce_test.go
@@ -177,7 +177,10 @@ func testListAndResolve(t *testing.T, c *configpb.Instances, testIndex int, ipTy
 	}
 	sort.Strings(expectedList)
 
-	gotList := gr.List()
+	var gotList []string
+	for _, ep := range gr.ListEndpoints() {
+		gotList = append(gotList, ep.Name)
+	}
 	sort.Strings(gotList)
 
 	if !reflect.DeepEqual(gotList, expectedList) {
@@ -299,7 +302,10 @@ func TestIPListFilteringByLabels(t *testing.T) {
 			}
 			gr := testGCEResources(t, c)
 
-			gotList := gr.List()
+			var gotList []string
+			for _, ep := range gr.ListEndpoints() {
+				gotList = append(gotList, ep.Name)
+			}
 			sort.Strings(gotList)
 
 			if !reflect.DeepEqual(gotList, test.want) {

--- a/targets/lameduck/lameduck.go
+++ b/targets/lameduck/lameduck.go
@@ -35,6 +35,7 @@ import (
 	rdspb "github.com/google/cloudprober/rds/proto"
 	"github.com/google/cloudprober/rds/server"
 	serverconfigpb "github.com/google/cloudprober/rds/server/proto"
+	"github.com/google/cloudprober/targets/endpoint"
 	configpb "github.com/google/cloudprober/targets/lameduck/proto"
 	targetspb "github.com/google/cloudprober/targets/proto"
 	"github.com/google/cloudprober/targets/rtc/rtcservice"
@@ -205,7 +206,7 @@ func (li *lister) initClients() error {
 func (li *lister) List() []string {
 	var result []string
 	for _, cl := range li.clients {
-		result = append(result, cl.List()...)
+		result = append(result, endpoint.NamesFromEndpoints(cl.ListEndpoints())...)
 	}
 
 	if len(result) != 0 {

--- a/targets/rtc/rtc.go
+++ b/targets/rtc/rtc.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/cloudprober/logger"
+	"github.com/google/cloudprober/targets/endpoint"
 	configpb "github.com/google/cloudprober/targets/rtc/proto"
 	cpb "github.com/google/cloudprober/targets/rtc/rtcreporter/proto"
 	"github.com/google/cloudprober/targets/rtc/rtcservice"
@@ -84,12 +85,7 @@ func (t *Targets) Resolve(name string, ipVer int) (net.IP, error) {
 	return ip, nil
 }
 
-// List produces a list of targets found in the RTC configuration for this
-// project. It ignores all sufficiently old RTC entries, as configured by
-// "exp_msec" in the TargetsConf protobuf. Then entries will be filtered by group
-// names, if "groups" was non-empty. If there is an empty intersection
-// between "groups" and the groups in RtcTargetInfo, the entry will be filtered out.
-func (t *Targets) List() []string {
+func (t *Targets) list() []string {
 	if t.cacheTicker == nil {
 		resp, err := t.evalList()
 		if err != nil {
@@ -100,6 +96,16 @@ func (t *Targets) List() []string {
 	t.cacheMu.RLock()
 	defer t.cacheMu.RUnlock()
 	return append([]string{}, t.cache...)
+}
+
+// ListEndpoints produces a list of targets found in the RTC configuration for
+// this project. It ignores all sufficiently old RTC entries, as configured by
+// "exp_msec" in the TargetsConf protobuf. Then entries will be filtered by
+// group names, if "groups" was non-empty. If there is an empty intersection
+// between "groups" and the groups in RtcTargetInfo, the entry will be filtered
+// out.
+func (t *Targets) ListEndpoints() []endpoint.Endpoint {
+	return endpoint.EndpointsFromNames(t.list())
 }
 
 // updateCacheResults tries to get the list of targets. It doesn't update cache

--- a/targets/rtc/rtc_test.go
+++ b/targets/rtc/rtc_test.go
@@ -237,11 +237,11 @@ Nextrow:
 			nameToIP: make(map[string]net.IP),
 		}
 		// List targets
-		gotlist := targs.List()
+		gotlist := targs.list()
 		// TODO(izzycecil): Need to catch errors with something like this. This
 		// requires looking at the logger.
 		// if (err != nil) != r.wantError {
-		// 	t.Errorf("%v: targs.List() gave error %q. r.wantError = %v", r.name, err, r.wantError)
+		// 	t.Errorf("%v: targs.list() gave error %q. r.wantError = %v", r.name, err, r.wantError)
 		// 	continue Nextrow
 		// }
 		// if err != nil {
@@ -374,7 +374,7 @@ Nextrow:
 			nameToIP: make(map[string]net.IP),
 		}
 		// List targets
-		got := targs.List()
+		got := targs.list()
 		sort.Strings(got)
 		sort.Strings(r.want)
 
@@ -444,7 +444,7 @@ Nextrow:
 			nameToIP: make(map[string]net.IP),
 		}
 		// List targets
-		got := targs.List()
+		got := targs.list()
 		sort.Strings(got)
 		sort.Strings(r.want)
 

--- a/targets/targets_test.go
+++ b/targets/targets_test.go
@@ -107,7 +107,7 @@ func TestList(t *testing.T) {
 				return
 			}
 
-			got := bt.List()
+			got := endpoint.NamesFromEndpoints(bt.ListEndpoints())
 			if !reflect.DeepEqual(got, r.expect) {
 				// Ignore the case when both slices are zero length, DeepEqual doesn't
 				// handle initialized but zero and non-initialized comparison very well.
@@ -141,7 +141,7 @@ func TestDummyTargets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("targets.New(...) Unexpected errors %v", err)
 	}
-	got := tgts.List()
+	got := endpoint.NamesFromEndpoints(tgts.ListEndpoints())
 	want := []string{""}
 	if !reflect.DeepEqual(got, []string{""}) {
 		t.Errorf("tgts.List() = %q, want %q", got, want)
@@ -162,9 +162,9 @@ func TestDummyTargets(t *testing.T) {
 
 func TestStaticTargets(t *testing.T) {
 	testHosts := "host1,host2"
-	tgts := targets.StaticTargets(testHosts)
-	if !reflect.DeepEqual(tgts.List(), strings.Split(testHosts, ",")) {
-		t.Errorf("StaticTargets not working as expected. Got list: %q, Expected: %s", tgts.List(), strings.Split(testHosts, ","))
+	got := endpoint.NamesFromEndpoints(targets.StaticTargets(testHosts).ListEndpoints())
+	if !reflect.DeepEqual(got, strings.Split(testHosts, ",")) {
+		t.Errorf("StaticTargets not working as expected. Got list: %q, Expected: %s", got, strings.Split(testHosts, ","))
 	}
 }
 
@@ -209,7 +209,7 @@ func TestGetExtensionTargets(t *testing.T) {
 	if err != nil {
 		t.Errorf("Got error in building targets from extensions: %v.", err)
 	}
-	tgtsList := tgts.List()
+	tgtsList := endpoint.NamesFromEndpoints(tgts.ListEndpoints())
 	if !reflect.DeepEqual(tgtsList, testTargets) {
 		t.Errorf("Extended targets: tgts.List()=%v, expected=%v", tgtsList, testTargets)
 	}
@@ -235,7 +235,7 @@ func TestSharedTargets(t *testing.T) {
 			t.Errorf("got error while creating targets from shared targets: %v", err)
 		}
 
-		got := tgts[i].List()
+		got := endpoint.NamesFromEndpoints(tgts[i].ListEndpoints())
 		if !reflect.DeepEqual(got, testHosts) {
 			t.Errorf("Unexpected targets: tgts.List()=%v, expected=%v", got, testHosts)
 		}


### PR DESCRIPTION
Targets' transition to ListEndpoints is complete now. Drop support for the old List() interface.

PiperOrigin-RevId: 306267875