### PR TITLE
Fix configtest functionality for configs with gceCustomMetadata macro.

### DIFF
--- a/cmd/cloudprober.go
+++ b/cmd/cloudprober.go
@@ -164,7 +164,7 @@ func main() {
 
 	if *configTest {
 		sysvars.Init(nil, configTestVars)
-		_, err := config.Parse(configFileToString(*configFile), sysvars.Vars())
+		_, err := config.ParseForTest(configFileToString(*configFile), sysvars.Vars())
 		if err != nil {
 			glog.Exitf("Error parsing config file. Err: %v", err)
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -76,3 +76,27 @@ probe {
 		t.Errorf("Incorrect probe name. Got: %s, Expected: %s", probeName, expectedName)
 	}
 }
+
+func TestParseForTest(t *testing.T) {
+	testConfig := `
+probe {
+  type: PING
+  name: "{{gceCustomMetadata "google-probe"}}"
+  targets {
+    host_names: "www.google.com"
+  }
+}
+`
+	c, err := ParseForTest(testConfig, map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(c.GetProbe()) != 1 {
+		t.Errorf("Didn't get correct number of probes. Got: %d, Expected: %d", len(c.GetProbe()), 1)
+	}
+	probeName := c.GetProbe()[0].GetName()
+	expectedName := "google-probe-test-value"
+	if probeName != expectedName {
+		t.Errorf("Incorrect probe name. Got: %s, Expected: %s", probeName, expectedName)
+	}
+}


### PR DESCRIPTION
gceCustomMetadata doesn't work in test environment as it requires access to GCE metadata.

PiperOrigin-RevId: 308766389