### PR TITLE
Refactor IP utilities to allow for better reuse of them.

### DIFF
--- a/common/iputils/iputils.go
+++ b/common/iputils/iputils.go
@@ -1,0 +1,82 @@
+// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package iputils implements utilities to work with IP addresses.
+*/
+package iputils
+
+import (
+	"fmt"
+	"net"
+)
+
+// IPVersion tells if an IP address is IPv4 or IPv6.
+func IPVersion(ip net.IP) int {
+	if len(ip.To4()) == net.IPv4len {
+		return 4
+	}
+	if len(ip) == net.IPv6len {
+		return 6
+	}
+	return 0
+}
+
+// Addr is used for tests, allowing net.InterfaceByName to be mocked.
+type Addr interface {
+	Addrs() ([]net.Addr, error)
+}
+
+// InterfaceByName is a mocking point for net.InterfaceByName, used for tests.
+var InterfaceByName = func(s string) (Addr, error) { return net.InterfaceByName(s) }
+
+// ResolveIntfAddr takes the name of a network interface and IP version, and
+// returns the first IP address of the interface that matches the specified IP
+// version. If no IP version is specified (ipVer is 0), simply the first IP
+// address is returned.
+// TODO(manugarg): This functions is currently tested through options_test. We
+// should fix that.
+func ResolveIntfAddr(intfName string, ipVer int) (net.IP, error) {
+	i, err := InterfaceByName(intfName)
+	if err != nil {
+		return nil, fmt.Errorf("resolveIntfAddr(%v, %d) got error getting interface: %v", intfName, ipVer, err)
+	}
+
+	addrs, err := i.Addrs()
+	if err != nil {
+		return nil, fmt.Errorf("resolveIntfAddr(%v, %d) got error getting addresses for interface: %v", intfName, ipVer, err)
+	} else if len(addrs) == 0 {
+		return nil, fmt.Errorf("resolveIntfAddr(%v, %d) go 0 addrs for interface", intfName, ipVer)
+	}
+
+	var ip net.IP
+
+	for _, addr := range addrs {
+		// i.Addrs() mostly returns network addresses of the form "172.17.90.252/23".
+		// This bit of code will pull the IP address from this address.
+		switch v := addr.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		default:
+			return nil, fmt.Errorf("resolveIntfAddr(%v, %d) found unknown type for first address: %T", intfName, ipVer, v)
+		}
+
+		if ipVer == 0 || IPVersion(ip) == ipVer {
+			return ip, nil
+		}
+	}
+	return nil, fmt.Errorf("resolveIntfAddr(%v, %d) found no apprpriate IP addresses in %v", intfName, ipVer, addrs)
+}

--- a/common/iputils/iputils_test.go
+++ b/common/iputils/iputils_test.go
@@ -1,0 +1,38 @@
+// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iputils
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIPVersion(t *testing.T) {
+	rows := []struct {
+		ip    string
+		ipVer int
+	}{
+		{"1.1.1.1", 4},
+		{"::1", 6},
+	}
+
+	for _, r := range rows {
+		ipVer := IPVersion(net.ParseIP(r.ip))
+
+		if ipVer != r.ipVer {
+			t.Errorf("Unexpected IPVersion want=%d, got=%d", r.ipVer, ipVer)
+		}
+	}
+}

--- a/probes/options/options.go
+++ b/probes/options/options.go
@@ -23,9 +23,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/cloudprober/common/iputils"
 	"github.com/google/cloudprober/logger"
 	"github.com/google/cloudprober/metrics"
-	"github.com/google/cloudprober/probes/probeutils"
 	configpb "github.com/google/cloudprober/probes/proto"
 	"github.com/google/cloudprober/targets"
 	"github.com/google/cloudprober/targets/lameduck"
@@ -128,14 +128,14 @@ func getSourceIPFromConfig(p *configpb.ProbeDef, l *logger.Logger) (net.IP, erro
 		}
 
 		// If ip_version is configured, make sure source_ip matches it.
-		if ipv(p.IpVersion) != 0 && probeutils.IPVersion(sourceIP) != ipv(p.IpVersion) {
+		if ipv(p.IpVersion) != 0 && iputils.IPVersion(sourceIP) != ipv(p.IpVersion) {
 			return nil, fmt.Errorf("configured source_ip (%s) doesn't match the ip_version (%d)", p.GetSourceIp(), ipv(p.IpVersion))
 		}
 
 		return sourceIP, nil
 
 	case *configpb.ProbeDef_SourceInterface:
-		return probeutils.ResolveIntfAddr(p.GetSourceInterface(), ipv(p.IpVersion))
+		return iputils.ResolveIntfAddr(p.GetSourceInterface(), ipv(p.IpVersion))
 
 	default:
 		return nil, fmt.Errorf("unknown source type: %v", p.GetSourceIpConfig())
@@ -187,7 +187,7 @@ func BuildProbeOptions(p *configpb.ProbeDef, ldLister lameduck.Lister, globalTar
 		}
 		// Set IPVersion from SourceIP if not already set.
 		if opts.IPVersion == 0 {
-			opts.IPVersion = probeutils.IPVersion(opts.SourceIP)
+			opts.IPVersion = iputils.IPVersion(opts.SourceIP)
 		}
 	}
 

--- a/probes/options/options_test.go
+++ b/probes/options/options_test.go
@@ -22,8 +22,8 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/google/cloudprober/common/iputils"
 	"github.com/google/cloudprober/logger"
-	"github.com/google/cloudprober/probes/probeutils"
 	configpb "github.com/google/cloudprober/probes/proto"
 	targetspb "github.com/google/cloudprober/targets/proto"
 )
@@ -42,7 +42,7 @@ func mockInterfaceByName(iname string, addrs []string) {
 		ips[i] = &net.IPAddr{IP: net.ParseIP(a)}
 	}
 	i := &intf{addrs: ips}
-	probeutils.InterfaceByName = func(name string) (probeutils.Addr, error) {
+	iputils.InterfaceByName = func(name string) (iputils.Addr, error) {
 		if name != iname {
 			return nil, errors.New("device not found")
 		}

--- a/probes/probeutils/probeutils.go
+++ b/probes/probeutils/probeutils.go
@@ -21,7 +21,6 @@ package probeutils
 import (
 	"bytes"
 	"fmt"
-	"net"
 )
 
 // PatternPayload builds a payload that can be verified using VerifyPayloadPattern.
@@ -54,61 +53,4 @@ func VerifyPayloadPattern(payload, pattern []byte) error {
 	}
 
 	return nil
-}
-
-// Addr is used for tests, allowing net.InterfaceByName to be mocked.
-type Addr interface {
-	Addrs() ([]net.Addr, error)
-}
-
-// InterfaceByName is a mocking point for net.InterfaceByName, used for tests.
-var InterfaceByName = func(s string) (Addr, error) { return net.InterfaceByName(s) }
-
-// ResolveIntfAddr takes the name of a network interface and IP version, and
-// returns the first IP address of the interface that matches the specified IP
-// version. If no IP version is specified (ipVer is 0), simply the first IP
-// address is returned.
-func ResolveIntfAddr(intfName string, ipVer int) (net.IP, error) {
-	i, err := InterfaceByName(intfName)
-	if err != nil {
-		return nil, fmt.Errorf("resolveIntfAddr(%v, %d) got error getting interface: %v", intfName, ipVer, err)
-	}
-
-	addrs, err := i.Addrs()
-	if err != nil {
-		return nil, fmt.Errorf("resolveIntfAddr(%v, %d) got error getting addresses for interface: %v", intfName, ipVer, err)
-	} else if len(addrs) == 0 {
-		return nil, fmt.Errorf("resolveIntfAddr(%v, %d) go 0 addrs for interface", intfName, ipVer)
-	}
-
-	var ip net.IP
-
-	for _, addr := range addrs {
-		// i.Addrs() mostly returns network addresses of the form "172.17.90.252/23".
-		// This bit of code will pull the IP address from this address.
-		switch v := addr.(type) {
-		case *net.IPNet:
-			ip = v.IP
-		case *net.IPAddr:
-			ip = v.IP
-		default:
-			return nil, fmt.Errorf("resolveIntfAddr(%v, %d) found unknown type for first address: %T", intfName, ipVer, v)
-		}
-
-		if ipVer == 0 || IPVersion(ip) == ipVer {
-			return ip, nil
-		}
-	}
-	return nil, fmt.Errorf("resolveIntfAddr(%v, %d) found no apprpriate IP addresses in %v", intfName, ipVer, addrs)
-}
-
-// IPVersion tells if an IP address is IPv4 or IPv6.
-func IPVersion(ip net.IP) int {
-	if len(ip.To4()) == net.IPv4len {
-		return 4
-	}
-	if len(ip) == net.IPv6len {
-		return 6
-	}
-	return 0
 }

--- a/probes/probeutils/probeutils_test.go
+++ b/probes/probeutils/probeutils_test.go
@@ -15,28 +15,9 @@
 package probeutils
 
 import (
-	"net"
 	"reflect"
 	"testing"
 )
-
-func TestIPVersion(t *testing.T) {
-	rows := []struct {
-		ip    string
-		ipVer int
-	}{
-		{"1.1.1.1", 4},
-		{"::1", 6},
-	}
-
-	for _, r := range rows {
-		ipVer := IPVersion(net.ParseIP(r.ip))
-
-		if ipVer != r.ipVer {
-			t.Errorf("Unexpected IPVersion want=%d, got=%d", r.ipVer, ipVer)
-		}
-	}
-}
 
 func TestPayloadVerification(t *testing.T) {
 	testBytes := []byte("test bytes")


### PR DESCRIPTION
Move IP utilities from probes/probeutils to common/iputils.

I found myself using the same methods while working on the file_based targets implementation.

PiperOrigin-RevId: 317436181