### PR TITLE
Keep track of connections done for keep_alive HTTP probes.

### DIFF
--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/http/httptrace"
 	"net/url"
 	"strconv"
 	"strings"
@@ -79,6 +80,7 @@ type Probe struct {
 
 type probeResult struct {
 	total, success, timeouts int64
+	connEvent                int64
 	latency                  metrics.Value
 	respCodes                *metrics.Map
 	respBodies               *metrics.Map
@@ -212,8 +214,22 @@ func isClientTimeout(err error) bool {
 
 // httpRequest executes an HTTP request and updates the provided result struct.
 func (p *Probe) doHTTPRequest(req *http.Request, result *probeResult, resultMu *sync.Mutex) {
-	start := time.Now()
 
+	if p.c.GetKeepAlive() {
+		trace := &httptrace.ClientTrace{
+			ConnectDone: func(_, addr string, err error) {
+				result.connEvent++
+				if err != nil {
+					p.l.Warning("Error establishing a new connection to: ", addr, ". Err: ", err.Error())
+					return
+				}
+				p.l.Info("Established a new connection to: ", addr)
+			},
+		}
+		req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+	}
+
+	start := time.Now()
 	resp, err := p.client.Do(req)
 	latency := time.Since(start)
 
@@ -382,6 +398,10 @@ func (p *Probe) Start(ctx context.Context, dataChan chan *metrics.EventMetrics) 
 					AddLabel("ptype", "http").
 					AddLabel("probe", p.name).
 					AddLabel("dst", target.Name)
+
+				if p.c.GetKeepAlive() {
+					em.AddMetric("connect_event", metrics.NewInt(result.connEvent))
+				}
 
 				for _, al := range p.opts.AdditionalLabels {
 					em.AddLabel(al.KeyValueForTarget(target.Name))


### PR DESCRIPTION
If keep_alive is enabled, use net/http/httptrace to get notified when new connections are done. On ConnectDone, update a new counter "connect_event" and log when connection takes place.

With this we'll see new connections in logs like this:
"Established a new connection to: 172.217.9.164:80"

PiperOrigin-RevId: 318599259