### PR TITLE
Improve cloudprober startup times

### DIFF
--- a/cmd/cloudprober.go
+++ b/cmd/cloudprober.go
@@ -48,7 +48,6 @@ var (
 	configTest       = flag.Bool("configtest", false, "Dry run to test config file")
 	dumpConfig       = flag.Bool("dumpconfig", false, "Dump processed config to stdout")
 	testInstanceName = flag.String("test_instance_name", "ig-us-central1-a-01-0000", "Instance name example to be used in tests")
-	nonCloud         = flag.Bool("non_cloud", false, "Disable cloud metadata collection")
 
 	// configTestVars provides a sane set of sysvars for config testing.
 	configTestVars = map[string]string(nil)
@@ -146,7 +145,6 @@ func main() {
 	flag.Parse()
 
 	runconfig.SetVersion(version)
-	runconfig.SetNonCloud(*nonCloud)
 
 	if *versionFlag {
 		fmt.Println(version)

--- a/cmd/cloudprober.go
+++ b/cmd/cloudprober.go
@@ -28,8 +28,9 @@ import (
 	"os/signal"
 	"runtime/pprof"
 
-	"cloud.google.com/go/compute/metadata"
 	"flag"
+
+	"cloud.google.com/go/compute/metadata"
 	"github.com/golang/glog"
 	"github.com/google/cloudprober"
 	"github.com/google/cloudprober/common/file"
@@ -47,6 +48,7 @@ var (
 	configTest       = flag.Bool("configtest", false, "Dry run to test config file")
 	dumpConfig       = flag.Bool("dumpconfig", false, "Dump processed config to stdout")
 	testInstanceName = flag.String("test_instance_name", "ig-us-central1-a-01-0000", "Instance name example to be used in tests")
+	nonCloud         = flag.Bool("non_cloud", false, "Disable cloud metadata collection")
 
 	// configTestVars provides a sane set of sysvars for config testing.
 	configTestVars = map[string]string(nil)
@@ -144,6 +146,7 @@ func main() {
 	flag.Parse()
 
 	runconfig.SetVersion(version)
+	runconfig.SetNonCloud(*nonCloud)
 
 	if *versionFlag {
 		fmt.Println(version)

--- a/config/runconfig/runconfig.go
+++ b/config/runconfig/runconfig.go
@@ -32,6 +32,7 @@ type runConfig struct {
 	sync.RWMutex
 	grpcSrv   *grpc.Server
 	version   string
+	nonCloud  bool
 	rdsServer *rdsserver.Server
 }
 
@@ -86,4 +87,21 @@ func LocalRDSServer() *rdsserver.Server {
 	rc.RLock()
 	defer rc.RUnlock()
 	return rc.rdsServer
+}
+
+// SetNonCloud sets the nonCloud flag to disable cloud metadata collection
+// It's useful for non-cloud environments, e.g. baremetal servers and
+// local development
+func SetNonCloud(flag bool) {
+	rc.Lock()
+	defer rc.Unlock()
+	rc.nonCloud = flag
+}
+
+// NonCloud returns the nonCloud flag, set through the
+// SetNonCloud() call.
+func NonCloud() bool {
+	rc.RLock()
+	defer rc.RUnlock()
+	return rc.nonCloud
 }

--- a/config/runconfig/runconfig.go
+++ b/config/runconfig/runconfig.go
@@ -32,7 +32,6 @@ type runConfig struct {
 	sync.RWMutex
 	grpcSrv   *grpc.Server
 	version   string
-	nonCloud  bool
 	rdsServer *rdsserver.Server
 }
 
@@ -87,21 +86,4 @@ func LocalRDSServer() *rdsserver.Server {
 	rc.RLock()
 	defer rc.RUnlock()
 	return rc.rdsServer
-}
-
-// SetNonCloud sets the nonCloud flag to disable cloud metadata collection
-// It's useful for non-cloud environments, e.g. baremetal servers and
-// local development
-func SetNonCloud(flag bool) {
-	rc.Lock()
-	defer rc.Unlock()
-	rc.nonCloud = flag
-}
-
-// NonCloud returns the nonCloud flag, set through the
-// SetNonCloud() call.
-func NonCloud() bool {
-	rc.RLock()
-	defer rc.RUnlock()
-	return rc.nonCloud
 }

--- a/sysvars/sysvars.go
+++ b/sysvars/sysvars.go
@@ -105,6 +105,11 @@ func Init(ll *logger.Logger, userVars map[string]string) error {
 	}
 	sysVars["hostname"] = hostname
 
+	// If not running in the cloud, do not set any extra variables
+	if runconfig.NonCloud() {
+		return nil
+	}
+
 	// If on GCE, add GCE variables.
 	if metadata.OnGCE() {
 		if err := gceVars(sysVars); err != nil {

--- a/sysvars/sysvars_ec2.go
+++ b/sysvars/sysvars_ec2.go
@@ -17,12 +17,15 @@ package sysvars
 import (
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 func ec2Vars(sysVars map[string]string) error {
-	s, err := session.NewSession()
+	s, err := session.NewSession(&aws.Config{
+		MaxRetries: aws.Int(0),
+	})
 	if err != nil {
 		return fmt.Errorf("ec2Vars: could not create session %v", err)
 	}


### PR DESCRIPTION
**What type of PR is this?** 
bugfix/improvement 

**Why is this pull request needed and what does it do?**
This PR introduces two distinct changes:
1. Speeds up cloudprober startup in non-cloud environments, e.g. baremetal servers or local development with the help of a new `non_cloud` flag. If this flag is set, all metadata collection functions are [skipped](https://github.com/google/cloudprober/compare/master...ori-edge:bug/417-Slow-startup-outside-of-public-clouds?expand=1#diff-74e5bb16a19d7f26583d399cd615a480R109).
2. Decreases the number of failed connection retries in AWS from 3 to 0. Cloudprober will only wait for the default 5 seconds for metadata service to respond and will not retry.

**Which issues (if any) are related?**
Issue #417 
