### PR TITLE
Handle external probe process termination more gracefully.

### DIFF
--- a/cmd/cloudprober.go
+++ b/cmd/cloudprober.go
@@ -27,6 +27,8 @@ import (
 	"os"
 	"os/signal"
 	"runtime/pprof"
+	"syscall"
+	"time"
 
 	"cloud.google.com/go/compute/metadata"
 	"flag"
@@ -42,6 +44,7 @@ import (
 var (
 	configFile       = flag.String("config_file", "", "Config file")
 	versionFlag      = flag.Bool("version", false, "Print version and exit")
+	stopTime         = flag.Duration("stop_time", 5*time.Second, "How long to wait for cleanup before process exits on SIGINT and SIGTERM")
 	cpuprofile       = flag.String("cpuprof", "", "Write cpu profile to file")
 	memprofile       = flag.String("memprof", "", "Write heap profile to file")
 	configTest       = flag.Bool("configtest", false, "Dry run to test config file")
@@ -181,7 +184,19 @@ func main() {
 	// web.Init sets up web UI for cloudprober.
 	web.Init()
 
-	cloudprober.Start(context.Background())
+	// Set up signal handling for the cancelation of the start context.
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	startCtx, cancelF := context.WithCancel(context.Background())
+
+	go func() {
+		sig := <-sigs
+		glog.Warningf("Received signal \"%v\", canceling the start context and waiting for %v before closing", sig, *stopTime)
+		cancelF()
+		time.Sleep(*stopTime)
+		os.Exit(0)
+	}()
+	cloudprober.Start(startCtx)
 
 	// Wait forever
 	select {}


### PR DESCRIPTION
= Use probe start context to start the external probe processes. This will make sure that external probe processes are killed cleanly once start context is canceled.
= On SIGINT and SIGTERM, cancel the start context and wait for a grace shutdown time period (default=5s).

This is in response to https://github.com/google/cloudprober/issues/413. I had been planning for this anyway.  We should also wire init context properly and make sure we can cleanup properly.

PiperOrigin-RevId: 318986425