### PR TITLE
Improve cloudprober startup time when not running on Cloud.

### DIFF
--- a/sysvars/sysvars_ec2.go
+++ b/sysvars/sysvars_ec2.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019-2020 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,12 +17,15 @@ package sysvars
 import (
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 func ec2Vars(sysVars map[string]string) error {
-	s, err := session.NewSession()
+	s, err := session.NewSession(&aws.Config{
+		MaxRetries: aws.Int(0),
+	})
 	if err != nil {
 		return fmt.Errorf("ec2Vars: could not create session %v", err)
 	}

--- a/sysvars/sysvars_test.go
+++ b/sysvars/sysvars_test.go
@@ -1,0 +1,38 @@
+// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysvars
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestProvidersToCheck(t *testing.T) {
+	flagToProviders := map[string][]string{
+		"auto": []string{"gce", "ec2"},
+		"gce":  []string{"gce"},
+		"ec2":  []string{"ec2"},
+		"none": nil,
+	}
+
+	for flagValue, expected := range flagToProviders {
+		t.Run("testing_with_cloud_metadata="+flagValue, func(t *testing.T) {
+			got := providersToCheck(flagValue)
+			if !reflect.DeepEqual(got, expected) {
+				t.Errorf("providersToCheck(%s)=%v, expected=%v", flagValue, got, expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
= Provide an option to disable cloud metadata checks.
= Set AWS API retries to 0. Metadata checks should not really require an automatic retry.

PiperOrigin-RevId: 319344649