### PR TITLE
Fix the concurrency bug introduced in the last change.

### DIFF
--- a/sysvars/sysvars.go
+++ b/sysvars/sysvars.go
@@ -194,7 +194,7 @@ func Start(ctx context.Context, dataChan chan *metrics.EventMetrics, interval ti
 
 		// Update timestamp and publish static variables.
 		em.Timestamp = ts
-		dataChan <- em
+		dataChan <- em.Clone()
 		l.Debug(em.String())
 
 		runtimeVars(dataChan, l)


### PR DESCRIPTION
Publish the cloned copy of the static EventMetrics, so that updating the timestamp in the next cycle doesn't race with the reads by the surfacers.

PiperOrigin-RevId: 319547864