### PR TITLE
kubernetes/services: Use ingress hostname if IP is empty but hostname is not.

### DIFF
--- a/rds/kubernetes/services.go
+++ b/rds/kubernetes/services.go
@@ -103,7 +103,8 @@ type serviceInfo struct {
 	Status struct {
 		LoadBalancer struct {
 			Ingress []struct {
-				IP string
+				IP       string
+				Hostname string
 			}
 		}
 	}
@@ -154,7 +155,12 @@ func (si *serviceInfo) resources(portFilter *filter.RegexFilter, reqIPType pb.IP
 			if len(si.Status.LoadBalancer.Ingress) == 0 {
 				continue
 			}
-			res.Ip = proto.String(si.Status.LoadBalancer.Ingress[0].IP)
+			ingress := si.Status.LoadBalancer.Ingress[0]
+
+			res.Ip = proto.String(ingress.IP)
+			if ingress.IP == "" && ingress.Hostname != "" {
+				res.Ip = proto.String(ingress.Hostname)
+			}
 		} else {
 			res.Ip = proto.String(si.Spec.ClusterIP)
 		}


### PR DESCRIPTION
RDS client has already been changed to DNS-resolve resource's IP if it's not a valid IP address.

This is to support Kubernetes cases where ingress is given a hostname instead of an IP address, for example, AWS ELB. See https://github.com/google/cloudprober/issues/418 for more details.

PiperOrigin-RevId: 320145826