### PR TITLE
Kubernetes RDS: Use name and namespace as resource keys instead of just names.

### DIFF
--- a/rds/kubernetes/endpoints_test.go
+++ b/rds/kubernetes/endpoints_test.go
@@ -15,20 +15,24 @@ func TestParseEndpoints(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error reading test data file: %s", epListFile)
 	}
-	_, epByName, err := parseEndpointsJSON(data)
+	_, epByKey, err := parseEndpointsJSON(data)
 	if err != nil {
 		t.Fatalf("error reading test data file: %s", epListFile)
 	}
 
-	testNames := []string{"cloudprober", "cloudprober-test", "kubernetes"}
-	for _, testP := range testNames {
-		if epByName[testP] == nil {
-			t.Errorf("didn't get endpoints by the name: %s", testP)
+	testKeys := []resourceKey{
+		{"default", "cloudprober"},
+		{"default", "cloudprober-test"},
+		{"system", "kubernetes"},
+	}
+	for _, key := range testKeys {
+		if epByKey[key] == nil {
+			t.Errorf("didn't get endpoints for %+v", key)
 		}
 	}
 
-	for _, name := range testNames[:1] {
-		epi := epByName[name]
+	for _, key := range testKeys[:1] {
+		epi := epByKey[key]
 		if epi.Metadata.Labels["app"] != "cloudprober" {
 			t.Errorf("cloudprober endpoints app label: got=%s, want=cloudprober", epi.Metadata.Labels["app"])
 		}

--- a/rds/kubernetes/kubernetes.go
+++ b/rds/kubernetes/kubernetes.go
@@ -98,6 +98,10 @@ type kMetadata struct {
 	Labels    map[string]string
 }
 
+type resourceKey struct {
+	namespace, name string
+}
+
 // ListResources returns the list of resources from the cache.
 func (p *Provider) ListResources(req *pb.ListResourcesRequest) (*pb.ListResourcesResponse, error) {
 	tok := strings.SplitN(req.GetResourcePath(), "/", 2)

--- a/rds/kubernetes/testdata/endpoints.json
+++ b/rds/kubernetes/testdata/endpoints.json
@@ -125,7 +125,7 @@
     {
       "metadata": {
         "name": "kubernetes",
-        "namespace": "default",
+        "namespace": "system",
         "selfLink": "/api/v1/namespaces/default/endpoints/kubernetes",
         "uid": "ae471cff-9b4f-11e8-a95e-42010a8a0ff8",
         "resourceVersion": "32",

--- a/rds/kubernetes/testdata/pods.json
+++ b/rds/kubernetes/testdata/pods.json
@@ -10,8 +10,174 @@
       "metadata": {
         "name": "cloudprober-54778d95f5-7hqtd",
         "generateName": "cloudprober-54778d95f5-",
-        "namespace": "default",
-        "selfLink": "/api/v1/namespaces/default/pods/cloudprober-54778d95f5-7hqtd",
+        "namespace": "prod",
+        "selfLink": "/api/v1/namespaces/prod/pods/cloudprober-54778d95f5-7hqtd",
+        "uid": "27b40427-be52-11e9-b3cb-42010a8a0172",
+        "resourceVersion": "60211894",
+        "creationTimestamp": "2019-08-14T05:12:47Z",
+        "labels": {
+          "app": "cloudprober",
+          "pod-template-hash": "1033485191"
+        },
+        "annotations": {
+          "kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container cloudprober"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "kind": "ReplicaSet",
+            "name": "cloudprober-54778d95f5",
+            "uid": "4d8dea4f-d753-11e8-ade0-42010a8a00bc",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ]
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "cloudprober-config",
+            "configMap": {
+              "name": "cloudprober-config",
+              "defaultMode": 420
+            }
+          },
+          {
+            "name": "default-token-fpbjc",
+            "secret": {
+              "secretName": "default-token-fpbjc",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "cloudprober",
+            "image": "cloudprober/cloudprober",
+            "args": [
+              "--config_file",
+              "/cfg/cloudprober.cfg",
+              "--logtostderr"
+            ],
+            "ports": [
+              {
+                "name": "http",
+                "containerPort": 9313,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "CLOUDPROBER_PORT",
+                "value": "9313"
+              }
+            ],
+            "resources": {
+              "requests": {
+                "cpu": "100m"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "cloudprober-config",
+                "mountPath": "/cfg"
+              },
+              {
+                "name": "default-token-fpbjc",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "gke-cluster-1-default-pool-abd8ad35-ccr7",
+        "securityContext": {
+
+        },
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0,
+        "enableServiceLinks": true
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-08-14T05:12:47Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-08-14T05:13:08Z"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": null
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2019-08-14T05:12:47Z"
+          }
+        ],
+        "hostIP": "10.138.0.5",
+        "podIP": "10.28.0.3",
+        "startTime": "2019-08-14T05:12:47Z",
+        "containerStatuses": [
+          {
+            "name": "cloudprober",
+            "state": {
+              "running": {
+                "startedAt": "2019-08-14T05:13:06Z"
+              }
+            },
+            "lastState": {
+
+            },
+            "ready": true,
+            "restartCount": 0,
+            "image": "cloudprober/cloudprober:latest",
+            "imageID": "docker-pullable://cloudprober/cloudprober@sha256:e6efb4057a41e8bb187508b68256df402d0c67b60ad6dfdfbce26a128d501efc",
+            "containerID": "docker://1dc2faec2892d334821fac4a1c460272114353154c239d2dd225d408fe100d62"
+          }
+        ],
+        "qosClass": "Burstable"
+      }
+    },
+    {
+      "metadata": {
+        "name": "cloudprober-54778d95f5-7hqtd",
+        "generateName": "cloudprober-54778d95f5-",
+        "namespace": "dev",
+        "selfLink": "/api/v1/namespaces/dev/pods/cloudprober-54778d95f5-7hqtd",
         "uid": "27b40427-be52-11e9-b3cb-42010a8a0172",
         "resourceVersion": "60211894",
         "creationTimestamp": "2019-08-14T05:12:47Z",

--- a/rds/kubernetes/testdata/services.json
+++ b/rds/kubernetes/testdata/services.json
@@ -136,7 +136,7 @@
     {
       "metadata": {
         "name": "kubernetes",
-        "namespace": "default",
+        "namespace": "system",
         "selfLink": "/api/v1/namespaces/default/services/kubernetes",
         "uid": "ae448b87-9b4f-11e8-a95e-42010a8a0ff8",
         "resourceVersion": "30",


### PR DESCRIPTION
In Kubernetes, resource may have the same name across namespaces. Currently, this can lead to a pretty bizarre behavior. See https://github.com/google/cloudprober/issues/436#issuecomment-669007829 for background.

PiperOrigin-RevId: 325143549