### PR TITLE
Metrics memory allocation visibility and performance improvements.

### DIFF
--- a/metrics/eventmetrics.go
+++ b/metrics/eventmetrics.go
@@ -193,6 +193,7 @@ func (em *EventMetrics) String() string {
 	defer em.mu.RUnlock()
 
 	var b strings.Builder
+	b.Grow(128)
 
 	b.WriteString(strconv.FormatInt(em.Timestamp.Unix(), 10))
 	// Labels section: labels=ptype=http,probe=homepage

--- a/metrics/map.go
+++ b/metrics/map.go
@@ -155,6 +155,8 @@ func (m *Map) String() string {
 	defer m.mu.RUnlock()
 
 	var b strings.Builder
+	b.Grow(64)
+
 	b.WriteString("map:")
 	b.WriteString(m.MapName)
 

--- a/metrics/map_test.go
+++ b/metrics/map_test.go
@@ -96,3 +96,19 @@ func TestMapString(t *testing.T) {
 		t.Errorf("ParseMapFromString(%s).String() = %s, expected = %s", s, s1, s)
 	}
 }
+
+func TestMapAllocsPerRun(t *testing.T) {
+	var v *Map
+	mapNewAvg := testing.AllocsPerRun(100, func() {
+		v = NewMap("code", NewInt(0))
+		v.IncKeyBy("200", NewInt(22))
+		v.IncKeyBy("404", NewInt(4500))
+		v.IncKeyBy("403", NewInt(4500))
+	})
+
+	mapStringAvg := testing.AllocsPerRun(100, func() {
+		_ = v.String()
+	})
+
+	t.Logf("Average allocations per run: ForMapNew=%v, ForMapString=%v", mapNewAvg, mapStringAvg)
+}


### PR DESCRIPTION
 = Export allocs per run for New() and String() functions of EventMetrics and Map.
 = Grow strings.Builder before writing to it, to reduce the number of allocations.

Allocs per run in string call:
Before: 12 (http://screen/KLKKM79AfSq)
After:   6 (http://screen/fVXeJHGudez)

We call String() a lot to export metrics. This change should help.

PiperOrigin-RevId: 325915027