### PR TITLE
Allow for request bodies larger than 32768 bytes.

### DIFF
--- a/probes/http/http_test.go
+++ b/probes/http/http_test.go
@@ -36,7 +36,8 @@ import (
 // The Transport is mocked instead of the Client because Client is not an
 // interface, but RoundTripper (which Transport implements) is.
 type testTransport struct {
-	noBody io.ReadCloser
+	noBody                   io.ReadCloser
+	lastProcessedRequestBody []byte
 }
 
 func newTestTransport() *testTransport {
@@ -70,6 +71,7 @@ func (tt *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 	req.Body.Close()
+	tt.lastProcessedRequestBody = b
 
 	return &http.Response{
 		Body: &testReadCloser{
@@ -190,6 +192,52 @@ func TestProbeWithBody(t *testing.T) {
 	got = p.results[testTarget].respBodies.String()
 	if got != expected {
 		t.Errorf("response map: got=%s, expected=%s", got, expected)
+	}
+}
+
+func TestProbeWithLargeBody(t *testing.T) {
+	for _, size := range []int{largeBodyThreshold - 1, largeBodyThreshold, largeBodyThreshold + 1, largeBodyThreshold * 2} {
+		t.Run(fmt.Sprintf("size:%d", size), func(t *testing.T) {
+			testProbeWithLargeBody(t, size)
+		})
+	}
+}
+
+func testProbeWithLargeBody(t *testing.T, bodySize int) {
+	testBody := strings.Repeat("a", bodySize)
+	testTarget := "test-large-body.com"
+
+	p := &Probe{}
+	err := p.Init("http_test", &options.Options{
+		Targets:  targets.StaticTargets(testTarget),
+		Interval: 2 * time.Second,
+		ProbeConf: &configpb.ProbeConf{
+			Body: &testBody,
+			// Can't use ExportResponseAsMetrics for large bodies,
+			// since maxResponseSizeForMetrics is small
+			ExportResponseAsMetrics: proto.Bool(false),
+		},
+	})
+
+	if err != nil {
+		t.Errorf("Error while initializing probe: %v", err)
+	}
+	testTransport := newTestTransport()
+	p.client.Transport = testTransport
+
+	// Probe 1st run
+	p.runProbe(context.Background())
+
+	got := string(testTransport.lastProcessedRequestBody)
+	if got != testBody {
+		t.Errorf("response body length: got=%d, expected=%d", len(got), len(testBody))
+	}
+
+	// Probe 2nd run (we should get the same request body).
+	p.runProbe(context.Background())
+	got = string(testTransport.lastProcessedRequestBody)
+	if got != testBody {
+		t.Errorf("response body length: got=%d, expected=%d", len(got), len(testBody))
 	}
 }
 

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -97,8 +97,8 @@ func (p *Probe) httpRequestForTarget(target endpoint.Endpoint, resolveF resolveF
 
 	// Prepare request body
 	var body io.Reader
-	if p.c.GetBody() != "" {
-		body = &requestBody{[]byte(p.c.GetBody())}
+	if len(p.requestBody) > 0 {
+		body = &requestBody{p.requestBody}
 	}
 	req, err := http.NewRequest(p.method, url, body)
 	if err != nil {


### PR DESCRIPTION
Currently request body reader returns io.EOF on the first "Read" itself. Default HTTP transport seems to use a byte slice of size 32768, which results in request body being truncated to 32768 bytes.

This change fixes that problem by using a buffered reader if request body is larger than a certain threshold (set to bytes.MinRead, same as used by ioutil.ReadAll).

PiperOrigin-RevId: 325915715