### PR TITLE
Update Deployment to apps/v1 in gh-pages

### DIFF
--- a/docs/content/how-to/run-on-kubernetes.md
+++ b/docs/content/how-to/run-on-kubernetes.md
@@ -40,12 +40,15 @@ kubectl create configmap cloudprober-config \
 Now let's add a `deployment.yaml` to add the config volume and cloudprober container:
 
 ```yaml
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cloudprober
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: cloudprober
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Since Deployment in apps/v1beta1 is no longer served in Kubernetes 1.16 and apps/v1 is available since v1.9, I updated the doc for Kubernetes to use Deployment in apps/v1.

FYI: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/