### PR TITLE
Fixed pointer bug in ListProbes() method in serviceimpl.go and the corresponding test.

### DIFF
--- a/prober/serviceimpl.go
+++ b/prober/serviceimpl.go
@@ -17,6 +17,7 @@ package prober
 import (
 	"context"
 
+	"github.com/golang/protobuf/proto"
 	pb "github.com/google/cloudprober/prober/proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -70,15 +71,10 @@ func (pr *Prober) ListProbes(ctx context.Context, req *pb.ListProbesRequest) (*p
 
 	resp := &pb.ListProbesResponse{}
 
-	keys := make([]string, 0)
-	for k, _ := range pr.Probes {
-		keys = append(keys, k)
-	}
-
-	for i := 0; i < len(keys); i++ {
+	for name, _ := range pr.Probes {
 		resp.Probe = append(resp.Probe, &pb.Probe{
-			Name:   &keys[i],
-			Config: pr.Probes[keys[i]].ProbeDef,
+			Name:   proto.String(name),
+			Config: pr.Probes[name].ProbeDef,
 		})
 	}
 

--- a/prober/serviceimpl.go
+++ b/prober/serviceimpl.go
@@ -69,10 +69,16 @@ func (pr *Prober) ListProbes(ctx context.Context, req *pb.ListProbesRequest) (*p
 	defer pr.mu.Unlock()
 
 	resp := &pb.ListProbesResponse{}
-	for name, p := range pr.Probes {
+
+	keys := make([]string, 0)
+	for k, _ := range pr.Probes {
+		keys = append(keys, k)
+	}
+
+	for i := 0; i < len(keys); i++ {
 		resp.Probe = append(resp.Probe, &pb.Probe{
-			Name:   &name,
-			Config: p.ProbeDef,
+			Name:   &keys[i],
+			Config: pr.Probes[keys[i]].ProbeDef,
 		})
 	}
 

--- a/prober/serviceimpl_test.go
+++ b/prober/serviceimpl_test.go
@@ -182,7 +182,7 @@ func TestListProbes(t *testing.T) {
 		respProbeNames = append(respProbeNames, p.GetName())
 	}
 	sort.Strings(respProbeNames)
-	if reflect.DeepEqual(respProbeNames, testProbes) {
+	if !reflect.DeepEqual(respProbeNames, testProbes) {
 		t.Errorf("Probes in ListProbes() response: %v, expected: %s", respProbeNames, testProbes)
 	}
 }


### PR DESCRIPTION
There is a pointer issue in the `ListProbes()` RPC. The `ListProbesResponse` object contains a list of structs, each containing a string and ProbeInfo object. If there are multiple probes added, the strings will all be the same as the last item added to this list.

Example: 
3 probes (probe0, probe1, probe2) are added. 
`ListProbes()` is called. 

Desired Response: ["probe0" <config>, "probe1" <config>, "probe2" <config>]
Received Response: ["probe2" <config>, "probe2" <config>, "probe2" <config>]

There is also a minor bug in the serviceimpl_test.go file.

https://github.com/google/cloudprober/blob/4cbdccb155c095efd4a7ace735fc0bd26c8c462d/prober/serviceimpl_test.go#L185-L187

There is a missing negation (!) in the if statement above, it should be:

```
if !reflect.DeepEqual(respProbeNames, testProbes) {
		t.Errorf("Probes in ListProbes() response: %v, expected: %s", respProbeNames, testProbes)
	}
```

Without the negation, this will only throw an error when these are the **same**, rather than **different**.

This pull request addresses both of these issues.
