### PR TITLE
HTTP probe: Use target's URL label only if relative_url is not config…

### DIFF
--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -23,6 +23,8 @@ import (
 	"github.com/google/cloudprober/targets/endpoint"
 )
 
+const relURLLabel = "relative_url"
+
 // requestBody encapsulates the request body and implements the io.Reader()
 // interface.
 type requestBody struct {
@@ -75,11 +77,15 @@ func urlHostForTarget(target endpoint.Endpoint) string {
 }
 
 func relURLForTarget(target endpoint.Endpoint, probeURL string) string {
-	if target.Labels["url"] != "" {
-		return target.Labels["url"]
+	if probeURL != "" {
+		return probeURL
 	}
 
-	return probeURL
+	if target.Labels[relURLLabel] != "" {
+		return target.Labels[relURLLabel]
+	}
+
+	return ""
 }
 
 func (p *Probe) httpRequestForTarget(target endpoint.Endpoint, resolveF resolveFunc) *http.Request {

--- a/probes/http/request_test.go
+++ b/probes/http/request_test.go
@@ -122,25 +122,33 @@ func TestURLHostAndHeaderForTarget(t *testing.T) {
 
 func TestRelURLforTarget(t *testing.T) {
 	for _, test := range []struct {
-		url        string
-		probeURL   string
-		wantRelURL string
+		targetURLLabel string
+		probeURL       string
+		wantRelURL     string
 	}{
 		{
-			url:        "/mymetrics",
-			probeURL:   "/metrics",
-			wantRelURL: "/mymetrics",
+			// Both set, probe URL wins.
+			targetURLLabel: "/target-url",
+			probeURL:       "/metrics",
+			wantRelURL:     "/metrics",
 		},
 		{
-			url:        "",
-			probeURL:   "/metrics",
-			wantRelURL: "/metrics",
+			// Only target label set.
+			targetURLLabel: "/target-url",
+			probeURL:       "",
+			wantRelURL:     "/target-url",
+		},
+		{
+			// Nothing set, we get nothing.
+			targetURLLabel: "",
+			probeURL:       "",
+			wantRelURL:     "",
 		},
 	} {
 		t.Run(fmt.Sprintf("test:%+v", test), func(t *testing.T) {
 			target := endpoint.Endpoint{
 				Name:   "test-target",
-				Labels: map[string]string{"url": test.url},
+				Labels: map[string]string{relURLLabel: test.targetURLLabel},
 			}
 
 			relURL := relURLForTarget(target, test.probeURL)


### PR DESCRIPTION
…ured in the probe.

Also rename the label to "relative_url", instead of just "url", to be more clear.

PiperOrigin-RevId: 331817695