### PR TITLE
Fallback for empty AccessToken

### DIFF
--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -312,7 +312,10 @@ func (p *Probe) updateTargets() {
 			if tok.AccessToken != "" {
 				p.bearerToken = tok.AccessToken
 			} else {
-				p.bearerToken = tok.Extra("id_token").(string)
+				idToken, ok := tok.Extra("id_token").(string)
+				if ok {
+					p.bearerToken = idToken
+				}
 			}
 			p.l.Debug("Got OAuth token, len: ", strconv.FormatInt(int64(len(p.bearerToken)), 10), ", expirationTime: ", tok.Expiry.String())
 		}

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -309,8 +309,12 @@ func (p *Probe) updateTargets() {
 		if err != nil {
 			p.l.Error("Error getting OAuth token: ", err.Error(), ". Skipping updating the token.")
 		} else {
-			p.l.Debug("Got OAuth token, len: ", strconv.FormatInt(int64(len(tok.AccessToken)), 10), ", expirationTime: ", tok.Expiry.String())
-			p.bearerToken = tok.AccessToken
+			if tok.AccessToken != "" {
+				p.bearerToken = tok.AccessToken
+			} else {
+				p.bearerToken = tok.Extra("id_token").(string)
+			}
+			p.l.Debug("Got OAuth token, len: ", strconv.FormatInt(int64(len(p.bearerToken)), 10), ", expirationTime: ", tok.Expiry.String())
 		}
 	}
 


### PR DESCRIPTION
Fallback to extra fields provided if AccessToken is empty (case witt GCP IAP)

Fixes #480