### PR TITLE
Check for ID token in OAuth token if access token is not set.

### DIFF
--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -309,8 +309,15 @@ func (p *Probe) updateTargets() {
 		if err != nil {
 			p.l.Error("Error getting OAuth token: ", err.Error(), ". Skipping updating the token.")
 		} else {
-			p.l.Debug("Got OAuth token, len: ", strconv.FormatInt(int64(len(tok.AccessToken)), 10), ", expirationTime: ", tok.Expiry.String())
-			p.bearerToken = tok.AccessToken
+			if tok.AccessToken != "" {
+				p.bearerToken = tok.AccessToken
+			} else {
+				idToken, ok := tok.Extra("id_token").(string)
+				if ok {
+					p.bearerToken = idToken
+				}
+			}
+			p.l.Debug("Got OAuth token, len: ", strconv.FormatInt(int64(len(p.bearerToken)), 10), ", expirationTime: ", tok.Expiry.String())
 		}
 	}
 


### PR DESCRIPTION
Some Google services, for example GCP IAP, don't set access token but set id_token in the OAuth token JSON. Use id_token if that's the case.

PiperOrigin-RevId: 335465851