### PR TITLE
Regitser channelz service to cloudprober default gRPC server. 

### DIFF
--- a/cloudprober.go
+++ b/cloudprober.go
@@ -44,6 +44,7 @@ import (
 	"github.com/google/cloudprober/surfacers"
 	"github.com/google/cloudprober/sysvars"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/channelz/service"
 	"google.golang.org/grpc/credentials"
 )
 
@@ -186,7 +187,10 @@ func InitFromConfig(configFile string) error {
 			serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(tlsConfig)))
 		}
 
-		runconfig.SetDefaultGRPCServer(grpc.NewServer(serverOpts...))
+		s := grpc.NewServer(serverOpts...)
+		// register channelz service to the default grpc server port
+		service.RegisterChannelzServiceToServer(s)
+		runconfig.SetDefaultGRPCServer(s)
 	}
 
 	pr := &prober.Prober{}


### PR DESCRIPTION
The default gRPC server will be created if the grpc_port field is specified in the prober.cfg file, and the channelz service use use the same port as the default gRPC server.

PiperOrigin-RevId: 335665796