### PR TITLE
Increase file surfacer buffer size to 10000 (from 1000).

### DIFF
--- a/surfacers/file/file.go
+++ b/surfacers/file/file.go
@@ -91,7 +91,7 @@ func (s *Surfacer) processInput(ctx context.Context) {
 }
 
 func (s *Surfacer) init(ctx context.Context, id int64) error {
-	s.inChan = make(chan *metrics.EventMetrics, 1000)
+	s.inChan = make(chan *metrics.EventMetrics, 10000)
 	s.id = id
 
 	// File handle for the output file


### PR DESCRIPTION
This will allow a bigger burst of EventMetrics and 10000 should not increase the memory usage by much.

PiperOrigin-RevId: 335890605