### PR TITLE
Implement GCE instances discovery using the API directly.

### DIFF
--- a/rds/gcp/forwarding_rules.go
+++ b/rds/gcp/forwarding_rules.go
@@ -19,6 +19,7 @@
 package gcp
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -29,6 +30,7 @@ import (
 	configpb "github.com/google/cloudprober/rds/gcp/proto"
 	pb "github.com/google/cloudprober/rds/proto"
 	"github.com/google/cloudprober/rds/server/filter"
+	"golang.org/x/oauth2/google"
 	compute "google.golang.org/api/compute/v1"
 )
 
@@ -175,6 +177,22 @@ func (frl *forwardingRulesLister) expand(reEvalInterval time.Duration) {
 	}
 
 	frl.l.Infof("forwarding_rules.expand: got %d forwarding rules", numItems)
+}
+
+// defaultComputeService returns a compute.Service object, initialized using
+// default credentials.
+func defaultComputeService(apiVersion string) (*compute.Service, error) {
+	client, err := google.DefaultClient(context.Background(), compute.ComputeScope)
+	if err != nil {
+		return nil, err
+	}
+	cs, err := compute.New(client)
+	if err != nil {
+		return nil, err
+	}
+
+	cs.BasePath = "https://www.googleapis.com/compute/" + apiVersion + "/projects/"
+	return cs, nil
 }
 
 func newForwardingRulesLister(project, apiVersion string, c *configpb.ForwardingRules, l *logger.Logger) (*forwardingRulesLister, error) {

--- a/rds/gcp/testdata/instances.json
+++ b/rds/gcp/testdata/instances.json
@@ -1,0 +1,56 @@
+{
+  "id": "instance-list",
+  "items": [
+    {
+      "name": "ig-us-central1-a-00-abcd",
+      "labels": {
+        "app": "cloudprober",
+        "shard": "00"
+      },
+      "networkInterfaces": [
+        {
+          "accessConfigs": [
+             {
+               "kind": "compute#accessConfig",
+               "name": "external-nat",
+               "natIP": "194.197.208.201",
+               "networkTier": "PREMIUM",
+               "type": "ONE_TO_ONE_NAT"
+             }
+          ],
+          "fingerprint": "DxvgIvO1QQ8=",
+          "kind": "compute#networkInterface",
+          "name": "nic0",
+          "network": "https://www.googleapis.com/compute/v1/projects/proj1/global/networks/default",
+          "networkIP": "10.0.0.2",
+          "subnetwork": "https://www.googleapis.com/compute/v1/projects/proj1/regions/us-central1/subnetworks/default"
+        },
+        {
+          "accessConfigs": [
+             {
+               "natIP": "194.197.208.202"
+             }
+          ],
+          "networkIP": "10.0.0.3"
+        }
+      ]
+    },
+    {
+      "name": "ig-us-central1-a-01-efgh",
+      "labels": {
+        "app": "cloudprober",
+        "shard": "01"
+      },
+      "networkInterfaces": [
+        {
+          "accessConfigs": [
+             {
+               "natIP": "194.197.209.202"
+             }
+          ],
+          "networkIP": "10.0.1.3"
+        }
+      ]
+    }
+  ]
+}

--- a/rds/gcp/testdata/zones.json
+++ b/rds/gcp/testdata/zones.json
@@ -1,0 +1,11 @@
+{
+  "id": "zones-list",
+  "items": [
+    {
+      "name": "us-central1-a"
+    },
+    {
+      "name": "us-central1-b"
+    }
+  ]
+}


### PR DESCRIPTION
Implement GCE instances discovery using the API directly (instead of API library).

= This will allow us to support early features that are not part of the API library yet.
= This is also more consistent with what we do for Kubernetes.

PiperOrigin-RevId: 341737797