### PR TITLE
Print Duration type as string, not decimal.

### DIFF
--- a/probes/udp/udp.go
+++ b/probes/udp/udp.go
@@ -162,7 +162,7 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 	}
 
 	if p.opts.StatsExportInterval < p.flushIntv {
-		return fmt.Errorf("UDP probe: stats_export_interval_msec (%d ms) is too low. It should be at least twice of the interval (%s) and timeout (%s), whichever is bigger", p.opts.StatsExportInterval, p.opts.Interval, p.opts.Timeout)
+		return fmt.Errorf("UDP probe: stats_export_interval_msec (%s) is too low. It should be at least twice of the interval (%s) and timeout (%s), whichever is bigger", p.opts.StatsExportInterval, p.opts.Interval, p.opts.Timeout)
 	}
 
 	// #send/recv-channel-buffer = #targets * #sources * #probing-intervals-between-flushes


### PR DESCRIPTION
Small cosmetic fix to an error message found while working on #511.

Before:
```
F1126 11:36:06.360134  422188 cloudprober.go:181] Error initializing cloudprober. Err: rpc error: code = Unknown desc = UDP probe: stats_export_interval_msec (500000000 ms) is too low. It should be at least twice of the interval (100ms) and timeout (2s), whichever is bigger
```

After:
```
F1126 11:37:32.736502  422349 cloudprober.go:181] Error initializing cloudprober. Err: rpc error: code = Unknown desc = UDP probe: stats_export_interval_msec (500ms) is too low. It should be at least twice of the interval (100ms) and timeout (2s), whichever is bigger
```
