### PR TITLE
Escape slashes in Stackdriver documentation

### DIFF
--- a/docs/content/surfacers/stackdriver.md
+++ b/docs/content/surfacers/stackdriver.md
@@ -56,7 +56,7 @@ For example, you can configure stackdriver surfacer to export only metrics that 
 surfacer {
   stackdriver_surfacer {
     # Export only "http" probe metrics.
-    allowed_metrics_regex: ".*\/http\/.*"
+    allowed_metrics_regex: ".*\\/http\\/.*"
   }
 }
 ```


### PR DESCRIPTION
Using `allowed_metrics_regex` from example gives:

```
invalid quoted string ".*\/http\/.*": unknown escape \/
```