### PR TITLE
Increase the robustness of end-to-end test - part II.

### DIFF
--- a/probes/http/http_test.go
+++ b/probes/http/http_test.go
@@ -280,7 +280,7 @@ func TestMultipleTargetsMultipleRequests(t *testing.T) {
 		"fail-test.com": 0, // Test transport is configured to fail this.
 	}
 
-	ems, err := testutils.MetricsFromChannel(dataChan, 10, time.Second)
+	ems, err := testutils.MetricsFromChannel(dataChan, 100, time.Second)
 	// We should receive at least 4 eventmetrics: 2 probe cycle x 2 targets.
 	if err != nil && len(ems) < 4 {
 		t.Errorf("Error getting 4 eventmetrics from data channel: %v", err)
@@ -295,6 +295,7 @@ func TestMultipleTargetsMultipleRequests(t *testing.T) {
 		successVals := dataMap["success"][tgt]
 		if len(successVals) < 1 {
 			t.Errorf("Success metric for %s: %v (less than 1)", tgt, successVals)
+			continue
 		}
 		latestVal := successVals[len(successVals)-1].Metric("success").(*metrics.Int).Int64()
 		if latestVal < wantSuccessVal {


### PR DESCRIPTION
= Read 100 instead of 10 EventMetrics. We are still running into cases where one target is able to produce 10 EventMetrics before any EventMetrics from another target show up. This caused one failure.

= Don't read stuff from slice if its length is 0 (less than 1).

I tested this change a few times (3 so far) to make sure this works:
https://github.com/google/cloudprober/pull/524

PiperOrigin-RevId: 346693076