### PR TITLE
Probe's errs field should be a pointer.

### DIFF
--- a/probes/udplistener/udplistener.go
+++ b/probes/udplistener/udplistener.go
@@ -77,7 +77,7 @@ type Probe struct {
 
 	// Process and output results synchronization.
 	mu   sync.Mutex
-	errs probeErr
+	errs *probeErr
 	res  map[string]*probeRunResult
 }
 
@@ -184,8 +184,10 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 	p.conn = conn
 
 	p.res = make(map[string]*probeRunResult)
-	p.errs.invalidMsgErrs = make(map[string]string)
-	p.errs.missingTargets = make(map[string]int)
+	p.errs = &probeErr{
+		invalidMsgErrs: make(map[string]string),
+		missingTargets: make(map[string]int),
+	}
 	return nil
 }
 

--- a/probes/udplistener/udplistener_test.go
+++ b/probes/udplistener/udplistener_test.go
@@ -144,7 +144,7 @@ func sendPktsAndCollectReplies(ctx context.Context, t *testing.T, srvPort int, i
 	return rxSeq
 }
 
-func runProbe(ctx context.Context, t *testing.T, inp *inputState) ([]int, chan statskeeper.ProbeResult, *probeRunResult, probeErr) {
+func runProbe(ctx context.Context, t *testing.T, inp *inputState) ([]int, chan statskeeper.ProbeResult, *probeRunResult, *probeErr) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 


### PR DESCRIPTION
In logErrs() we create a copy of p.errs. That ends up creating a new probeErrors struct instead of just creating a new reference (copy of the pointer). When we replace invalidMsgErrs and missingTargets in the copy of p.errs, we change only the new struct:
  pe := p.errs
  ..
  pe.invalidMsgErrs = make(map[string]string)
  ..
  pe.missingTargets = make(map[string]int

Storing a pointer will make sure that we are modifying the probe's errs object.

PiperOrigin-RevId: 347708735