### PR TITLE
Static targets handling improvements.

### DIFF
--- a/probes/grpc/grpc.go
+++ b/probes/grpc/grpc.go
@@ -24,6 +24,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"strconv"
 	"sync"
 	"time"
 
@@ -155,7 +157,7 @@ func (p *Probe) updateTargetsAndStartProbes(ctx context.Context) {
 	activeTargets := make(map[string]bool)
 	// Create results structure and start probe loop for new targets.
 	for _, tgtEp := range newTargets {
-		tgt := tgtEp.Name
+		tgt := net.JoinHostPort(tgtEp.Name, strconv.Itoa(tgtEp.Port))
 		activeTargets[tgt] = true
 		if _, ok := p.results[tgt]; ok {
 			continue

--- a/probes/http/http_test.go
+++ b/probes/http/http_test.go
@@ -247,7 +247,7 @@ func testProbeWithLargeBody(t *testing.T, bodySize int) {
 }
 
 func TestMultipleTargetsMultipleRequests(t *testing.T) {
-	testTargets := []string{"test.com", "fail-test.com", "http://www.google.com"}
+	testTargets := []string{"test.com", "fail-test.com", "fails-to-resolve.com"}
 	reqPerProbe := int64(3)
 	opts := &options.Options{
 		Targets:             targets.StaticTargets(strings.Join(testTargets, ",")),
@@ -283,7 +283,7 @@ func TestMultipleTargetsMultipleRequests(t *testing.T) {
 		"fail-test.com": [2]int64{0, 2 * reqPerProbe},
 
 		// No probes sent because of bad target (http)
-		"http://www.google.com": [2]int64{0, 0},
+		"fails-to-resolve.com": [2]int64{0, 0},
 	}
 
 	ems, err := testutils.MetricsFromChannel(dataChan, 100, time.Second)

--- a/targets/statictargets.go
+++ b/targets/statictargets.go
@@ -1,0 +1,79 @@
+// Copyright 2021 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package targets
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/google/cloudprober/targets/endpoint"
+)
+
+func staticTargets(hosts string) (Targets, error) {
+	t, _ := baseTargets(nil, nil, nil)
+	sl := &staticLister{}
+
+	for _, host := range strings.Split(hosts, ",") {
+		host = strings.TrimSpace(host)
+
+		// Make sure there is no "/" in the host name. That typically happens
+		// when users accidentally add URLs in hostnames.
+		if strings.IndexByte(host, '/') >= 0 {
+			return nil, fmt.Errorf("invalid host (%s), contains '/'", host)
+		}
+
+		hostColonParts := strings.Split(host, ":")
+
+		// There is no colon in host name.
+		if len(hostColonParts) == 1 {
+			sl.list = append(sl.list, endpoint.Endpoint{Name: host})
+			continue
+		}
+
+		// There is only 1 colon, assume it is for the port. An IPv6 address will
+		// more than 1 colon.
+		if len(hostColonParts) == 2 {
+			portNum, err := strconv.Atoi(hostColonParts[1])
+			if err != nil {
+				return nil, fmt.Errorf("error parsing port(%s): %v", hostColonParts[1], err)
+			}
+			sl.list = append(sl.list, endpoint.Endpoint{Name: hostColonParts[0], Port: portNum})
+			continue
+		}
+
+		// More than 1 colon. It should include an IPv6 address.
+		// 1. Parses as an IP address. If that fails,
+		// 2. Parse for IPv6 and port.
+		if ip := net.ParseIP(host); ip != nil {
+			sl.list = append(sl.list, endpoint.Endpoint{Name: host})
+			continue
+		}
+		hostname, port, err := net.SplitHostPort(host)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing host(%s) as hostport: %v", host, err)
+		}
+		portNum, err := strconv.Atoi(port)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing port(%s): %v", port, err)
+		}
+		sl.list = append(sl.list, endpoint.Endpoint{Name: hostname, Port: portNum})
+	}
+
+	t.lister = sl
+	t.resolver = globalResolver
+	return t, nil
+}

--- a/targets/statictargets_test.go
+++ b/targets/statictargets_test.go
@@ -1,0 +1,76 @@
+// Copyright 2021 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package targets
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/cloudprober/targets/endpoint"
+)
+
+func TestStaticTargets(t *testing.T) {
+	for _, test := range []struct {
+		desc      string
+		hosts     string
+		wantNames []string
+		wantPorts []int
+		wantErr   bool
+	}{
+		{
+			desc:      "valid hosts (extra space)",
+			hosts:     "www.google.com ,127.0.0.1, 2001::2001",
+			wantNames: []string{"www.google.com", "127.0.0.1", "2001::2001"},
+			wantPorts: []int{0, 0, 0},
+		},
+		{
+			desc:      "Ports in name",
+			hosts:     "www.google.com:80,127.0.0.1:8080,[2001::2001]:8081",
+			wantNames: []string{"www.google.com", "127.0.0.1", "2001::2001"},
+			wantPorts: []int{80, 8080, 8081},
+		},
+		{
+			desc:    "invalid host, IPv6 port in name without brackets",
+			hosts:   "www.google.com,127.0.0.1:8080,0:0:0:0:0:1:8081",
+			wantErr: true,
+		},
+		{
+			desc:    "invalid hosts,URL in name",
+			hosts:   "www.google.com/url1,127.0.0.1,2001::2001",
+			wantErr: true,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			tgts, err := staticTargets(test.hosts)
+			if err != nil {
+				if !test.wantErr {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				return
+			}
+			if test.wantErr {
+				t.Errorf("wanted error, but didn't get one")
+			}
+			wantEp := make([]endpoint.Endpoint, len(test.wantNames))
+			for i := 0; i < len(wantEp); i++ {
+				wantEp[i] = endpoint.Endpoint{Name: test.wantNames[i], Port: test.wantPorts[i]}
+			}
+			got := tgts.ListEndpoints()
+			if !reflect.DeepEqual(got, wantEp) {
+				t.Errorf("staticTargets: got=%v, wanted: %v", got, wantEp)
+			}
+		})
+	}
+}

--- a/targets/targets_test.go
+++ b/targets/targets_test.go
@@ -172,14 +172,6 @@ func TestDummyTargets(t *testing.T) {
 	}
 }
 
-func TestStaticTargets(t *testing.T) {
-	testHosts := "host1,host2"
-	got := endpoint.NamesFromEndpoints(StaticTargets(testHosts).ListEndpoints())
-	if !reflect.DeepEqual(got, strings.Split(testHosts, ",")) {
-		t.Errorf("StaticTargets not working as expected. Got list: %q, Expected: %s", got, strings.Split(testHosts, ","))
-	}
-}
-
 type testTargetsType struct {
 	names []string
 }


### PR DESCRIPTION
Sometimes users put ports and URLs in static hostnames. Currently, either we silently drop such hosts, for example when doing HTTP probing, or use hostport as it is, for example in gRPC probe. Make this behavior consistent:

- Parse ports in host spec (e.g. test.com:8080) and create an endpoint.Endpoint from host-port combination. This will work across all probes.

- Check for forward-slashes in target host names, and fail if there are any.

More context: https://github.com/google/cloudprober/issues/543#issuecomment-754943940

PiperOrigin-RevId: 350508273