### PR TITLE
Fix "divide by zero" in HTTP probe

### DIFF
--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -446,7 +446,7 @@ func (p *Probe) gapBetweenTargets() time.Duration {
 
 	// If not configured by user, determine based on probe interval and number of
 	// targets.
-	if interTargetGap == 0 {
+	if interTargetGap == 0 && len(p.targets) != 0 {
 		// Use 1/10th of the probe interval to spread out target groroutines.
 		interTargetGap = p.opts.Interval / time.Duration(10*len(p.targets))
 	}


### PR DESCRIPTION
Log:
```
panic: runtime error: integer divide by zero

goroutine 77 [running]:
github.com/google/cloudprober/probes/http.(*Probe).gapBetweenTargets(...)
```

Found by playing with `file_targets`.

Minimum configuration to reproduce:

```
probe {
  name: "1"
  type: HTTP

  targets {
    file_targets {
      file_path: "/dev/null"
      re_eval_sec: 1
    }
  }

  http_probe {
      interval_between_targets_msec: 0
  }
}
```

PiperOrigin-RevId: 359324571