### PR TITLE
More optimizations for the UDP server code.

### DIFF
--- a/servers/udp/udp.go
+++ b/servers/udp/udp.go
@@ -20,11 +20,15 @@ package udp
 
 import (
 	"context"
+	"fmt"
 	"net"
+	"strings"
 
 	"github.com/google/cloudprober/logger"
 	"github.com/google/cloudprober/metrics"
 	configpb "github.com/google/cloudprober/servers/udp/proto"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
 )
 
 const (
@@ -39,6 +43,11 @@ type Server struct {
 	c    *configpb.ServerConf
 	conn *net.UDPConn
 	l    *logger.Logger
+
+	// IPv4 and IPv6 connection types are initialized and used only on
+	// non-windows systems.
+	p6 *ipv6.PacketConn
+	p4 *ipv4.PacketConn
 }
 
 // New returns an UDP server.
@@ -52,11 +61,13 @@ func New(initCtx context.Context, c *configpb.ServerConf, l *logger.Logger) (*Se
 		conn.Close()
 	}()
 
-	return &Server{
+	s := &Server{
 		c:    c,
 		conn: conn,
 		l:    l,
-	}, nil
+	}
+
+	return s, s.initConnection()
 }
 
 // Listen opens a UDP socket on the given port. It also attempts to set recv
@@ -76,6 +87,67 @@ func Listen(addr *net.UDPAddr, l *logger.Logger) (*net.UDPConn, error) {
 	return conn, nil
 }
 
+func (s *Server) readPacket(buf []byte) (int, *ipv6.ControlMessage, net.Addr, error) {
+	// If protocol level packet connection is available (work only on
+	// non-windows), use low-level read.
+	if s.p6 == nil {
+		len, addr, err := s.conn.ReadFromUDP(buf)
+		return len, nil, addr, err
+	}
+	return s.p6.ReadFrom(buf)
+}
+
+func (s *Server) writePacket(buf []byte, cm *ipv6.ControlMessage, addr net.Addr) (int, error) {
+	// If no control message (should happen only on windows), use high-level UDP
+	// write function.
+	if cm == nil {
+		return s.conn.WriteToUDP(buf, addr.(*net.UDPAddr))
+	}
+
+	// We have an IPv4 address.
+	if cm.Dst.To4() != nil {
+		wcm := &ipv4.ControlMessage{
+			Src: cm.Dst.To4(),
+		}
+		return s.p4.WriteTo(buf, wcm, addr)
+	}
+
+	// Assume IPv6 address.
+	wcm := &ipv6.ControlMessage{
+		Src: cm.Dst.To16(),
+	}
+	return s.p6.WriteTo(buf, wcm, addr)
+}
+
+// readAndEcho reads a packet from the server connection and writes it back. To
+// determine the source address for outgoing packets (e.g. if server is behind
+// a load balancer), we make use of control messages (Note: this doesn't work
+// on Windows OS as Go doesn't provide a way to access control messages on
+// Windows).
+func (s *Server) readAndEcho(buf []byte) (error, error) {
+	inLen, cm, addr, err := s.readPacket(buf)
+	if err != nil {
+		return fmt.Errorf("error reading from UDP: %v", err), err
+	}
+
+	n, err := s.writePacket(buf[:inLen], cm, addr)
+	if err != nil {
+		return fmt.Errorf("error writing to UDP: %v", err), err
+	}
+
+	if n < inLen {
+		s.l.Warningf("Reply truncated! Got %d bytes but only sent %d bytes", inLen, n)
+	}
+
+	return nil, nil
+}
+
+func connClosed(err error) bool {
+	// TODO(manugarg): Replace this by errors.Is(err, net.ErrClosed) once Go 1.16
+	// is more widely available.
+	return strings.Contains(err.Error(), "use of closed network connection")
+}
+
 // Start starts the UDP server. It returns only when context is canceled.
 func (s *Server) Start(ctx context.Context, dataChan chan<- *metrics.EventMetrics) error {
 	// TODO(manugarg): We read and echo back only 4098 bytes. We should look at raising this
@@ -83,21 +155,36 @@ func (s *Server) Start(ctx context.Context, dataChan chan<- *metrics.EventMetric
 	// (up to the max size of 64K-sizeof(UDPHdr)) and discards the rest.
 	buf := make([]byte, 4098)
 
+	// Setup a background function to close connection if context is canceled.
+	// Typically, this is not what we want (close something started outside of
+	// Start function), but in case of UDP we don't have better control than
+	// this. One thing we can consider is to re-setup connection in Start().
+	go func() {
+		<-ctx.Done()
+		s.conn.Close()
+	}()
+
 	switch s.c.GetType() {
 
 	case configpb.ServerConf_ECHO:
 		s.l.Infof("Starting UDP ECHO server on port %d", int(s.c.GetPort()))
-		readAndEchoLoop(ctx, s.conn, buf, s.l)
+		for {
+			if err, nestedErr := s.readAndEcho(buf); err != nil {
+				if connClosed(nestedErr) {
+					s.l.Warning("connection closed, stopping the start goroutine")
+					return nil
+				}
+				s.l.Error(err.Error())
+			}
+		}
 
 	case configpb.ServerConf_DISCARD:
 		s.l.Infof("Starting UDP DISCARD server on port %d", int(s.c.GetPort()))
 		for {
-			select {
-			case <-ctx.Done():
-				return s.conn.Close()
-			default:
-			}
 			if _, _, err := s.conn.ReadFromUDP(buf); err != nil {
+				if connClosed(err) {
+					return nil
+				}
 				s.l.Errorf("ReadFromUDP: %v", err)
 			}
 		}

--- a/servers/udp/udp.go
+++ b/servers/udp/udp.go
@@ -143,6 +143,10 @@ func (s *Server) readAndEcho(buf []byte) (error, error) {
 }
 
 func connClosed(err error) bool {
+	// ReadFromUDP returns net.OpError
+	if opErr, ok := err.(*net.OpError); ok {
+		err = opErr.Err
+	}
 	// TODO(manugarg): Replace this by errors.Is(err, net.ErrClosed) once Go 1.16
 	// is more widely available.
 	return strings.Contains(err.Error(), "use of closed network connection")

--- a/servers/udp/udp_nonwindows.go
+++ b/servers/udp/udp_nonwindows.go
@@ -17,68 +17,22 @@
 package udp
 
 import (
-	"context"
 	"fmt"
-	"io"
-	"net"
 
-	"github.com/google/cloudprober/logger"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
 )
 
-func readAndEchoLoop(ctx context.Context, conn *net.UDPConn, buf []byte, l *logger.Logger) error {
+func (s *Server) initConnection() error {
 	// We use an IPv6 connection wrapper to receive both IPv4 and IPv6 packets.
 	// ipv6.PacketConn lets us use control messages to:
 	//  -- receive packet destination IP (FlagDst)
 	//  -- set source IP (Src).
-	p6 := ipv6.NewPacketConn(conn)
-	if err := p6.SetControlMessage(ipv6.FlagDst, true); err != nil {
+	s.p6 = ipv6.NewPacketConn(s.conn)
+	if err := s.p6.SetControlMessage(ipv6.FlagDst, true); err != nil {
 		return fmt.Errorf("error running SetControlMessage(FlagDst): %v", err)
 	}
-	p4 := ipv4.NewPacketConn(conn)
+	s.p4 = ipv4.NewPacketConn(s.conn)
 
-	for {
-		select {
-		case <-ctx.Done():
-			return conn.Close()
-		default:
-		}
-		readAndEchoNonWindows(p6, p4, buf, l)
-	}
-}
-
-func readAndEchoNonWindows(p6 *ipv6.PacketConn, p4 *ipv4.PacketConn, buf []byte, l *logger.Logger) {
-	// ipv6.PacketConn also receives IPv4 packets.
-	len, cm, addr, err := p6.ReadFrom(buf)
-	if err != nil {
-		l.Errorf("ReadFrom(): %v", err)
-		return
-	}
-
-	var n int
-	if cm.Dst.To4() != nil {
-		// We have a v4 packet, use an ipv4.PacketConn for sending.
-		wcm := &ipv4.ControlMessage{
-			Src: cm.Dst.To4(),
-		}
-		n, err = p4.WriteTo(buf[:len], wcm, addr)
-	} else {
-		// We have a v6 packet.
-		wcm := &ipv6.ControlMessage{
-			Src: cm.Dst.To16(),
-		}
-		n, err = p6.WriteTo(buf[:len], wcm, addr)
-	}
-
-	if err == io.EOF {
-		return
-	}
-	if err != nil {
-		l.Errorf("WriteTo(): %v", err)
-		return
-	}
-	if n < len {
-		l.Warningf("Reply truncated! Got %v bytes but only sent %v bytes", len, n)
-	}
+	return nil
 }

--- a/servers/udp/udp_test.go
+++ b/servers/udp/udp_test.go
@@ -168,6 +168,8 @@ func testServerStopWithConfig(t *testing.T, testConfig *configpb.ServerConf) {
 	if err != nil {
 		t.Errorf("Error connecting to test UDP server (%s): %v", serverAddr, err)
 	}
+	conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
+
 	for i := 0; true; i++ {
 		_, err := conn.Write(make([]byte, 10))
 		if err == nil {

--- a/servers/udp/udp_windows.go
+++ b/servers/udp/udp_windows.go
@@ -16,41 +16,6 @@
 
 package udp
 
-import (
-	"context"
-	"io"
-	"net"
-
-	"github.com/google/cloudprober/logger"
-)
-
-func readAndEchoLoop(ctx context.Context, conn *net.UDPConn, buf []byte, l *logger.Logger) error {
-	for {
-		select {
-		case <-ctx.Done():
-			return conn.Close()
-		default:
-		}
-		readAndEchoWindows(conn, buf, l)
-	}
-}
-
-func readAndEchoWindows(conn *net.UDPConn, buf []byte, l *logger.Logger) {
-	len, addr, err := conn.ReadFromUDP(buf)
-	if err != nil {
-		l.Errorf("ReadFromUDP: %v", err)
-		return
-	}
-
-	n, err := conn.WriteToUDP(buf[:len], addr)
-	if err == io.EOF {
-		return
-	}
-	if err != nil {
-		l.Errorf("WriteToUDP: %v", err)
-		return
-	}
-	if n < len {
-		l.Warningf("Reply truncated! Got %v bytes but only sent %v bytes", len, n)
-	}
+func (s *Server) initConnection() error {
+	return nil
 }


### PR DESCRIPTION
= Initialize connections during New() and call different code for windows and non-windows platforms. Note that lenins@ also originally suggested initializing IPv4 and IPv6 packet conn during New(), but we reverted that because SetControlMessage doesn't work on Windows.

= Move all of ReadAndEcho code back to udp.go and select different code paths based on whether IPv6 connection is initialized or not.

PiperOrigin-RevId: 360550473