### PR TITLE
WIP: Show probe name in file_targets log messages

### DIFF
--- a/prober/prober.go
+++ b/prober/prober.go
@@ -169,7 +169,7 @@ func (pr *Prober) Init(ctx context.Context, cfg *configpb.ProberConfig, l *logge
 
 	// Initialize shared targets
 	for _, st := range pr.c.GetSharedTargets() {
-		tgts, err := targets.New(st.GetTargets(), pr.ldLister, globalTargetsOpts, pr.l, pr.l)
+		tgts, err := targets.New(st.GetName(), st.GetTargets(), pr.ldLister, globalTargetsOpts, pr.l, pr.l)
 		if err != nil {
 			return err
 		}

--- a/probes/options/options.go
+++ b/probes/options/options.go
@@ -123,7 +123,7 @@ func BuildProbeOptions(p *configpb.ProbeDef, ldLister endpoint.Lister, globalTar
 		return nil, fmt.Errorf("error in initializing logger for the probe (%s): %v", p.GetName(), err)
 	}
 
-	if opts.Targets, err = targets.New(p.GetTargets(), ldLister, globalTargetsOpts, l, opts.Logger); err != nil {
+	if opts.Targets, err = targets.New(p.GetName(), p.GetTargets(), ldLister, globalTargetsOpts, l, opts.Logger); err != nil {
 		return nil, err
 	}
 

--- a/targets/file/file.go
+++ b/targets/file/file.go
@@ -49,6 +49,7 @@ type Targets struct {
 	labelsFilter *filter.LabelsFilter
 	mu           sync.RWMutex
 	l            *logger.Logger
+	probeName    string
 }
 
 /*
@@ -73,7 +74,7 @@ var SupportedFilters = struct {
 }
 
 // New returns new file targets.
-func New(opts *configpb.TargetsConf, res *dnsRes.Resolver, l *logger.Logger) (*Targets, error) {
+func New(probeName string, opts *configpb.TargetsConf, res *dnsRes.Resolver, l *logger.Logger) (*Targets, error) {
 	ft := &Targets{
 		path:      opts.GetFilePath(),
 		resources: make(map[string]*rdspb.Resource),
@@ -93,6 +94,7 @@ func New(opts *configpb.TargetsConf, res *dnsRes.Resolver, l *logger.Logger) (*T
 	}
 
 	ft.nameFilter, ft.labelsFilter = allFilters.RegexFilters["name"], allFilters.LabelsFilter
+	ft.probeName = probeName
 
 	if opts.GetReEvalSec() == 0 {
 		return ft, ft.refresh()
@@ -193,7 +195,7 @@ func (ft *Targets) parseFileContent(b []byte) error {
 	}
 	ft.names = ft.names[:i]
 
-	ft.l.Infof("file_targets(%s): Read %d resources, kept %d after filtering", ft.path, len(resources.GetResource()), len(ft.names))
+	ft.l.Infof("Probe(%s), file_targets(%s): Read %d resources, kept %d after filtering", ft.probeName, ft.path, len(resources.GetResource()), len(ft.names))
 	return nil
 }
 

--- a/targets/file/file_test.go
+++ b/targets/file/file_test.go
@@ -166,7 +166,7 @@ func testFileTargetsForType(t *testing.T, fileType string) {
 	t.Helper()
 	testFile := createTestFile(t, fileType)
 
-	ft, err := New(&configpb.TargetsConf{FilePath: proto.String(testFile)}, nil, nil)
+	ft, err := New("Probe1", &configpb.TargetsConf{FilePath: proto.String(testFile)}, nil, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error while parsing textpb: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestListEndpointsWithFilter(t *testing.T) {
 
 	testFile := createTestFile(t, "")
 
-	ft, err := New(&configpb.TargetsConf{
+	ft, err := New("Probe1", &configpb.TargetsConf{
 		FilePath: proto.String(testFile),
 		Filter: []*rdspb.Filter{
 			{

--- a/targets/targets.go
+++ b/targets/targets.go
@@ -308,7 +308,7 @@ func RDSClientConf(pb *targetspb.RDSTargets, globalOpts *targetspb.GlobalTargets
 //
 // See cloudprober/targets/targets.proto for more information on the possible
 // configurations of Targets.
-func New(targetsDef *targetspb.TargetsDef, ldLister endpoint.Lister, globalOpts *targetspb.GlobalTargetsOptions, globalLogger, l *logger.Logger) (Targets, error) {
+func New(probeName string, targetsDef *targetspb.TargetsDef, ldLister endpoint.Lister, globalOpts *targetspb.GlobalTargetsOptions, globalLogger, l *logger.Logger) (Targets, error) {
 	t, err := baseTargets(targetsDef, ldLister, l)
 	if err != nil {
 		globalLogger.Error("Unable to produce the base target lister")
@@ -353,7 +353,7 @@ func New(targetsDef *targetspb.TargetsDef, ldLister endpoint.Lister, globalOpts 
 		t.lister, t.resolver = client, client
 
 	case *targetspb.TargetsDef_FileTargets:
-		ft, err := file.New(targetsDef.GetFileTargets(), globalResolver, l)
+		ft, err := file.New(probeName, targetsDef.GetFileTargets(), globalResolver, l)
 		if err != nil {
 			return nil, fmt.Errorf("target.New(): %v", err)
 		}

--- a/targets/targets_test.go
+++ b/targets/targets_test.go
@@ -149,7 +149,7 @@ func TestDummyTargets(t *testing.T) {
 		},
 	}
 	l := &logger.Logger{}
-	tgts, err := New(targetsDef, nil, nil, nil, l)
+	tgts, err := New("Probe1", targetsDef, nil, nil, nil, l)
 	if err != nil {
 		t.Fatalf("New(...) Unexpected errors %v", err)
 	}
@@ -201,7 +201,7 @@ func TestGetExtensionTargets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error setting up extension in test targets proto: %v", err)
 	}
-	tgts, err := New(targetsDef, nil, nil, nil, nil)
+	tgts, err := New("Probe1", targetsDef, nil, nil, nil, nil)
 	if err == nil {
 		t.Errorf("Expected error in building targets from extensions, got nil. targets: %v", tgts)
 	}
@@ -209,7 +209,7 @@ func TestGetExtensionTargets(t *testing.T) {
 	RegisterTargetsType(200, func(conf interface{}, l *logger.Logger) (Targets, error) {
 		return &testTargetsType{names: testTargets}, nil
 	})
-	tgts, err = New(targetsDef, nil, nil, nil, nil)
+	tgts, err = New("Probe1", targetsDef, nil, nil, nil, nil)
 	if err != nil {
 		t.Errorf("Got error in building targets from extensions: %v.", err)
 	}
@@ -233,7 +233,7 @@ func TestSharedTargets(t *testing.T) {
 		}
 
 		var err error
-		tgts[i], err = New(targetsDef, nil, nil, nil, nil)
+		tgts[i], err = New("Probe1", targetsDef, nil, nil, nil, nil)
 
 		if err != nil {
 			t.Errorf("got error while creating targets from shared targets: %v", err)


### PR DESCRIPTION
By using same file_path in multiple probes it is not
possible to distinguish which one was logged.

This is bare minimum and under discussion. If this is usable for community I can improve (e.g. add to all log messages etc).