### PR TITLE
Update copyright header for cloudprober.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,15 @@
+# This is the list of Cloudprober authors for copyright purposes.
+#
+# This does not list everyone who has contributed code. To see the full list of
+# contributors, see the revision history in source control.
+
+Google Inc.
+
+# Primary author:
+Manu Garg <manugarg@google.com>
+
+# Partial list of contributors:
+Lenin Singaravelu <lenins@google.com>
+Nerijus Bendžiūnas <nerijus.bendziunas@hostinger.com>
+Rob Pickerill <r.pickerill@gmail.com>
+Christopher Broglie <cbroglie@cloudflare.com>

--- a/cloudprober.go
+++ b/cloudprober.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cloudprober_test.go
+++ b/cloudprober_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Google Inc.
+// Copyright 2019-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/cloudprober.go
+++ b/cmd/cloudprober.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/file/file.go
+++ b/common/file/file.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google Inc.
+// Copyright 2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/file/file_test.go
+++ b/common/file/file_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google Inc.
+// Copyright 2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/iputils/iputils.go
+++ b/common/iputils/iputils.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google Inc.
+// Copyright 2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/iputils/iputils_test.go
+++ b/common/iputils/iputils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google Inc.
+// Copyright 2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/message/message.go
+++ b/common/message/message.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Google Inc.
+// Copyright 2017-2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/message/message_test.go
+++ b/common/message/message_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Google Inc.
+// Copyright 2017-2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/oauth/bearer.go
+++ b/common/oauth/bearer.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/oauth/bearer_test.go
+++ b/common/oauth/bearer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/oauth/oauth.go
+++ b/common/oauth/oauth.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/oauth/oauth_test.go
+++ b/common/oauth/oauth_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/tlsconfig/tlsconfig.go
+++ b/common/tlsconfig/tlsconfig.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/config/config.go
+++ b/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/config/runconfig/runconfig.go
+++ b/config/runconfig/runconfig.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/contrib/gcp/bigquery/bigquery.go
+++ b/contrib/gcp/bigquery/bigquery.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google Inc.
+// Copyright 2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/contrib/gcp/cmd/bigquery_probe.go
+++ b/contrib/gcp/cmd/bigquery_probe.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google Inc.
+// Copyright 2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metrics/dist.go
+++ b/metrics/dist.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metrics/dist_test.go
+++ b/metrics/dist_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metrics/eventmetrics.go
+++ b/metrics/eventmetrics.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metrics/eventmetrics_test.go
+++ b/metrics/eventmetrics_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metrics/float.go
+++ b/metrics/float.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metrics/int.go
+++ b/metrics/int.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metrics/map.go
+++ b/metrics/map.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metrics/map_test.go
+++ b/metrics/map_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metrics/payload/payload.go
+++ b/metrics/payload/payload.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metrics/payload/payload_test.go
+++ b/metrics/payload/payload_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metrics/string.go
+++ b/metrics/string.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metrics/string_test.go
+++ b/metrics/string_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metrics/testutils/testutils.go
+++ b/metrics/testutils/testutils.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metrics/testutils/testutils_test.go
+++ b/metrics/testutils/testutils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/prober/cmd/client.go
+++ b/prober/cmd/client.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/prober/prober.go
+++ b/prober/prober.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/prober/serviceimpl.go
+++ b/prober/serviceimpl.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/prober/serviceimpl_test.go
+++ b/prober/serviceimpl_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/common/statskeeper/statskeeper.go
+++ b/probes/common/statskeeper/statskeeper.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/common/statskeeper/statskeeper_test.go
+++ b/probes/common/statskeeper/statskeeper_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/dns/cmd/dns.go
+++ b/probes/dns/cmd/dns.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/dns/dns.go
+++ b/probes/dns/dns.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/dns/dns_test.go
+++ b/probes/dns/dns_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/external/cmd/external.go
+++ b/probes/external/cmd/external.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/external/external.go
+++ b/probes/external/external.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/external/external_test.go
+++ b/probes/external/external_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/external/serverutils/serverutils.go
+++ b/probes/external/serverutils/serverutils.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/grpc/grpc.go
+++ b/probes/grpc/grpc.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google Inc.
+// Copyright 2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/http/cmd/http.go
+++ b/probes/http/cmd/http.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Google Inc.
+// Copyright 2017-2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/http/http_test.go
+++ b/probes/http/http_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Google Inc.
+// Copyright 2019-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/http/request_test.go
+++ b/probes/http/request_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Google Inc.
+// Copyright 2019-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/options/labels.go
+++ b/probes/options/labels.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/options/labels_test.go
+++ b/probes/options/labels_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/options/options.go
+++ b/probes/options/options.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/options/options_test.go
+++ b/probes/options/options_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/ping/cmd/ping.go
+++ b/probes/ping/cmd/ping.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/ping/icmpconn_nonunix.go
+++ b/probes/ping/icmpconn_nonunix.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google Inc.
+// Copyright 2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/ping/icmpconn_unix.go
+++ b/probes/ping/icmpconn_unix.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google Inc.
+// Copyright 2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/ping/ping.go
+++ b/probes/ping/ping.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/ping/ping_test.go
+++ b/probes/ping/ping_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/ping/pingutils.go
+++ b/probes/ping/pingutils.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/ping/pingutils_test.go
+++ b/probes/ping/pingutils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/probes.go
+++ b/probes/probes.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/probes_status_tmpl.go
+++ b/probes/probes_status_tmpl.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/probes_test.go
+++ b/probes/probes_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/probeutils/probeutils.go
+++ b/probes/probeutils/probeutils.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/probeutils/probeutils_test.go
+++ b/probes/probeutils/probeutils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/udp/cmd/udp.go
+++ b/probes/udp/cmd/udp.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/udp/udp.go
+++ b/probes/udp/udp.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/udp/udp_test.go
+++ b/probes/udp/udp_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/udplistener/udplistener.go
+++ b/probes/udplistener/udplistener.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/probes/udplistener/udplistener_test.go
+++ b/probes/udplistener/udplistener_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/client/client.go
+++ b/rds/client/client.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 Google Inc.
+// Copyright 2018-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/client/client_test.go
+++ b/rds/client/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 Google Inc.
+// Copyright 2018-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/client/cmd/client.go
+++ b/rds/client/cmd/client.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/client/srvlist.go
+++ b/rds/client/srvlist.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google Inc.
+// Copyright 2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/client/srvlist_test.go
+++ b/rds/client/srvlist_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google Inc.
+// Copyright 2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/gcp/forwarding_rules.go
+++ b/rds/gcp/forwarding_rules.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google Inc.
+// Copyright 2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/gcp/gce_instances.go
+++ b/rds/gcp/gce_instances.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/gcp/gce_instances_test.go
+++ b/rds/gcp/gce_instances_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/gcp/gcp.go
+++ b/rds/gcp/gcp.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/gcp/gcp_test.go
+++ b/rds/gcp/gcp_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/gcp/pubsub.go
+++ b/rds/gcp/pubsub.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/gcp/pubsub_test.go
+++ b/rds/gcp/pubsub_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/gcp/rtc_variables.go
+++ b/rds/gcp/rtc_variables.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/gcp/rtc_variables_test.go
+++ b/rds/gcp/rtc_variables_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/kubernetes/client.go
+++ b/rds/kubernetes/client.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/kubernetes/client_test.go
+++ b/rds/kubernetes/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/kubernetes/endpoints.go
+++ b/rds/kubernetes/endpoints.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/kubernetes/ingresses.go
+++ b/rds/kubernetes/ingresses.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google Inc.
+// Copyright 2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/kubernetes/ingresses_test.go
+++ b/rds/kubernetes/ingresses_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google Inc.
+// Copyright 2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/kubernetes/kubernetes.go
+++ b/rds/kubernetes/kubernetes.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/kubernetes/kubernetes_test.go
+++ b/rds/kubernetes/kubernetes_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/kubernetes/pods.go
+++ b/rds/kubernetes/pods.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/kubernetes/pods_test.go
+++ b/rds/kubernetes/pods_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/kubernetes/services.go
+++ b/rds/kubernetes/services.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/kubernetes/services_test.go
+++ b/rds/kubernetes/services_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/server/filter/filter.go
+++ b/rds/server/filter/filter.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Google Inc.
+// Copyright 2017-2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/server/filter/filter_test.go
+++ b/rds/server/filter/filter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rds/server/server.go
+++ b/rds/server/server.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servers/external/external.go
+++ b/servers/external/external.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google Inc.
+// Copyright 2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servers/grpc/grpc.go
+++ b/servers/grpc/grpc.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servers/grpc/grpc_test.go
+++ b/servers/grpc/grpc_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servers/http/http.go
+++ b/servers/http/http.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servers/http/http_test.go
+++ b/servers/http/http_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servers/servers.go
+++ b/servers/servers.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servers/udp/cmd/udp.go
+++ b/servers/udp/cmd/udp.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servers/udp/udp.go
+++ b/servers/udp/udp.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servers/udp/udp_nonwindows.go
+++ b/servers/udp/udp_nonwindows.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servers/udp/udp_test.go
+++ b/servers/udp/udp_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/servers/udp/udp_windows.go
+++ b/servers/udp/udp_windows.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/surfacers/cloudwatch/cloudwatch.go
+++ b/surfacers/cloudwatch/cloudwatch.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Google Inc.
+// Copyright 2021 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/surfacers/cloudwatch/cloudwatch_test.go
+++ b/surfacers/cloudwatch/cloudwatch_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Google Inc.
+// Copyright 2021 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/surfacers/common/compress/compress.go
+++ b/surfacers/common/compress/compress.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 Google Inc.
+// Copyright 2017-2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/surfacers/common/compress/compress_test.go
+++ b/surfacers/common/compress/compress_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/surfacers/common/options/options.go
+++ b/surfacers/common/options/options.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Google Inc.
+// Copyright 2021 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/surfacers/file/file.go
+++ b/surfacers/file/file.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/surfacers/file/file_test.go
+++ b/surfacers/file/file_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/surfacers/postgres/postgres.go
+++ b/surfacers/postgres/postgres.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this postgres except in compliance with the License.

--- a/surfacers/prometheus/prometheus.go
+++ b/surfacers/prometheus/prometheus.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/surfacers/prometheus/prometheus_test.go
+++ b/surfacers/prometheus/prometheus_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/surfacers/pubsub/pubsub.go
+++ b/surfacers/pubsub/pubsub.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google Inc.
+// Copyright 2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/surfacers/pubsub/pubsub_test.go
+++ b/surfacers/pubsub/pubsub_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google Inc.
+// Copyright 2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/surfacers/stackdriver/stackdriver.go
+++ b/surfacers/stackdriver/stackdriver.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/surfacers/stackdriver/stackdriver_test.go
+++ b/surfacers/stackdriver/stackdriver_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/surfacers/surfacers.go
+++ b/surfacers/surfacers.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 Google Inc.
+// Copyright 2017-2021 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/surfacers/surfacers_test.go
+++ b/surfacers/surfacers_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sysvars/sysvars.go
+++ b/sysvars/sysvars.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 Google Inc.
+// Copyright 2017-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sysvars/sysvars_ec2.go
+++ b/sysvars/sysvars_ec2.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Google Inc.
+// Copyright 2019-2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sysvars/sysvars_gce.go
+++ b/sysvars/sysvars_gce.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sysvars/sysvars_test.go
+++ b/sysvars/sysvars_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google Inc.
+// Copyright 2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/targets/endpoint/endpoint.go
+++ b/targets/endpoint/endpoint.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/targets/endpoint/endpoint_test.go
+++ b/targets/endpoint/endpoint_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/targets/file/file.go
+++ b/targets/file/file.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google Inc.
+// Copyright 2020 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/targets/gce/forwarding_rules.go
+++ b/targets/gce/forwarding_rules.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/targets/gce/gce.go
+++ b/targets/gce/gce.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/targets/gce/gce_test.go
+++ b/targets/gce/gce_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/targets/gce/gce_utils.go
+++ b/targets/gce/gce_utils.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/targets/gce/gce_utils_test.go
+++ b/targets/gce/gce_utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/targets/lameduck/lameduck.go
+++ b/targets/lameduck/lameduck.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/targets/lameduck/lameduck_test.go
+++ b/targets/lameduck/lameduck_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/targets/resolver/resolver.go
+++ b/targets/resolver/resolver.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/targets/resolver/resolver_test.go
+++ b/targets/resolver/resolver_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/targets/rtc/rtcservice/rtcservice.go
+++ b/targets/rtc/rtcservice/rtcservice.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/targets/rtc/rtcservice/rtcservice_stub.go
+++ b/targets/rtc/rtcservice/rtcservice_stub.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/targets/rtc/rtcservice/rtcservice_test.go
+++ b/targets/rtc/rtcservice/rtcservice_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2017 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/targets/statictargets.go
+++ b/targets/statictargets.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Google Inc.
+// Copyright 2021 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/targets/statictargets_test.go
+++ b/targets/statictargets_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Google Inc.
+// Copyright 2021 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/targets/targets.go
+++ b/targets/targets.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/targets/targets_test.go
+++ b/targets/targets_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Google Inc.
+// Copyright 2017-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/validators/http/http.go
+++ b/validators/http/http.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/validators/http/http_test.go
+++ b/validators/http/http_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/validators/integrity/integrity.go
+++ b/validators/integrity/integrity.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/validators/integrity/integrity_test.go
+++ b/validators/integrity/integrity_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/validators/regex/regex.go
+++ b/validators/regex/regex.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/validators/regex/regex_test.go
+++ b/validators/regex/regex_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/validators/validators.go
+++ b/validators/validators.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 Google Inc.
+// Copyright 2018-2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/validators/validators_test.go
+++ b/validators/validators_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc.
+// Copyright 2019 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/web/formatutils/formatutils.go
+++ b/web/formatutils/formatutils.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/web/web.go
+++ b/web/web.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2018 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
= Change from Google Inc to The Cloudprober Authors.
= Add an AUTHORS file.

Reference: http://go/releasing/authors
PiperOrigin-RevId: 371006068