### PR TITLE
Docs: Filtering Metrics in Surfacers

### DIFF
--- a/docs/content/surfacers/cloudwatch.md
+++ b/docs/content/surfacers/cloudwatch.md
@@ -79,13 +79,6 @@ The full list of configuration options for the cloudwatch surfacer is:
   // The cloudwatch resolution value, lowering this below 60 will incur
   // additional charges as the metrics will be charged at a high resolution rate.
   optional int64 resolution = 2 [default=60];
-
-  // If allowed_metrics_regex is specified, only metrics matching the given
-  // regular expression will be exported to cloudwatch. This will be evaluated
-  // against both the probe type and probe name.
-  // Example:
-  // allowed_metrics_regex: "(http|ping)"
-  optional string allowed_metrics_regex = 3;
 ```
 
 (Source: https://github.com/google/cloudprober/blob/master/surfacers/cloudwatch/proto/config.proto)

--- a/docs/content/surfacers/overview.md
+++ b/docs/content/surfacers/overview.md
@@ -17,6 +17,7 @@ Cloudprober currently supports following surfacer types:
 * Google Pub/Sub ([config](https://github.com/google/cloudprober/blob/master/surfacers/pubsub/proto/config.proto))
 * Postgres ([config](https://github.com/google/cloudprober/blob/master/surfacers/postgres/proto/config.proto))
 * File ([config](https://github.com/google/cloudprober/blob/master/surfacers/file/proto/config.proto))
+* [Cloudwatch (AWS Cloud Monitoring)](/surfacers/cloudwatch)
 
 Source: [surfacers config](https://github.com/google/cloudprober/blob/7bc30b62e42f3fe4e8a2fb8cd0e87ea18b73aeb8/surfacers/proto/config.proto#L14).
 
@@ -33,7 +34,7 @@ Adding surfacers to cloudprober is as easy as adding "surfacer" config stanzas t
 # scraping by prometheus.
 surfacer {
   type: PROMETHEUS
-  
+
   prometheus_surfacer {
     # Following option adds a prefix to exported metrics, for example,
     # "total" metric is exported as "cloudprober_total".
@@ -48,3 +49,66 @@ surfacer {
 }
 ```
 
+### Filtering Metrics
+
+It is possible to filter the metrics that the surfacers receive.
+
+#### Filtering by Label
+
+Cloudprober can filter the metrics that are published to surfacers. To filter metrics by labels, reference one of the following keys in the surfacer configuration:
+
+- `allow_metrics_with_label`
+- `ignore_metrics_with_label`
+
+_Note: `ignore_metrics_with_label` takes precedence over `allow_metrics_with_label`._
+
+For example, to ignore all sysvar metrics:
+
+```
+surfacer {
+  type: PROMETHEUS
+
+  ignore_metrics_with_label {
+    key: "probe",
+    value: "sysvars",
+  }
+}
+```
+Or to only allow metrics from http probes:
+
+```
+surfacer {
+  type: PROMETHEUS
+
+  allow_metrics_with_label {
+    key: "ptype",
+    value: "http",
+  }
+}
+```
+
+#### Filtering by Metric Name
+
+For certain surfacers, cloudprober can filter the metrics that are published by name. The surfacers that support this functionality are:
+
+- Cloudwatch
+- Prometheus
+- Stackdriver
+
+Within the surfacer configuration, the following options are defined:
+
+- `allow_metrics_with_name`
+- `ignore_metrics_with_name`
+
+_Note: `ignore_metrics_with_name` takes precedence over `allow_metrics_with_name`._
+
+To filter out all `validation_failure` metrics by name:
+
+```
+surfacer {
+  type: PROMETHEUS
+
+  ignore_metrics_with_name: "validation_failure"
+}
+```
+(Source: https://github.com/google/cloudprober/blob/master/surfacers/proto/config.proto)


### PR DESCRIPTION
Staging this PR to align filtering docs as a follow on for #597. I'd spotted the cloudwatch docs needed a quick update so I took the opportunity to also write a bit of documentation for filtering metrics.

I'd also spotted I'd missed the surfacers overview -> cloudwatch reference so added that here.

There is a minor code change in the protobuf config and tests for cloudwatch so I think this PR needs splitting again? Let me know what's best.
