### PR TITLE
Remove individual add-failure-metric implementations.

### DIFF
--- a/surfacers/cloudwatch/cloudwatch_test.go
+++ b/surfacers/cloudwatch/cloudwatch_test.go
@@ -268,47 +268,6 @@ func TestNewCWMetricDatum(t *testing.T) {
 	}
 }
 
-func TestCalculateFailureMetric(t *testing.T) {
-	timestamp := time.Now()
-
-	tests := map[string]struct {
-		em      *metrics.EventMetrics
-		want    float64
-		wantErr string
-	}{
-		"simple": {
-			em: metrics.NewEventMetrics(timestamp).
-				AddLabel("ptype", "http").
-				AddMetric("total", metrics.NewFloat(10)).
-				AddMetric("success", metrics.NewFloat(5)),
-			want:    float64(5),
-			wantErr: "",
-		},
-		"string metric": {
-			em: metrics.NewEventMetrics(timestamp).
-				AddLabel("ptype", "http").
-				AddMetric("total", metrics.NewFloat(10)).
-				AddMetric("success", metrics.NewString("5")),
-			want:    float64(0),
-			wantErr: "unexpected",
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			gotFailure, err := calculateFailureMetric(tc.em)
-
-			if !ErrorContains(err, tc.wantErr) {
-				t.Errorf("unexpected error: %s", err)
-			}
-
-			if gotFailure != tc.want {
-				t.Errorf("Return failure metric check: got: %f, want: %f", gotFailure, tc.want)
-			}
-		})
-	}
-}
-
 func ErrorContains(out error, want string) bool {
 	if out == nil {
 		return want == ""

--- a/surfacers/common/options/options.go
+++ b/surfacers/common/options/options.go
@@ -158,7 +158,11 @@ func BuildOptionsFromConfig(sdef *surfacerpb.SurfacerDef, l *logger.Logger) (*Op
 	}
 
 	opts.AddFailureMetric = opts.Config.GetAddFailureMetric()
-	if opts.Config.AddFailureMetric == nil && opts.Config.GetType() == surfacerpb.Type_STACKDRIVER {
+	defaultFailureMetric := map[surfacerpb.Type]bool{
+		surfacerpb.Type_STACKDRIVER: true,
+		surfacerpb.Type_CLOUDWATCH:  true,
+	}
+	if opts.Config.AddFailureMetric == nil && defaultFailureMetric[opts.Config.GetType()] {
 		opts.AddFailureMetric = true
 	}
 

--- a/surfacers/common/transform/transform.go
+++ b/surfacers/common/transform/transform.go
@@ -25,22 +25,22 @@ import (
 
 // AddFailureMetric adds failure metric to the EventMetrics based on the
 // config options.
-func AddFailureMetric(em *metrics.EventMetrics, l *logger.Logger) {
+func AddFailureMetric(em *metrics.EventMetrics) error {
 	tv, sv, fv := em.Metric("total"), em.Metric("success"), em.Metric("failure")
 	// If there is already a failure metric, or if "total" and "success" metrics
 	// are not available, don't compute failure metric.
 	if fv != nil || tv == nil || sv == nil {
-		return
+		return nil
 	}
 
 	total, totalOk := tv.(metrics.NumValue)
 	success, successOk := sv.(metrics.NumValue)
 	if !totalOk || !successOk {
-		l.Errorf("total (%v) and success (%v) values are not numeric, this should never happen", tv, sv)
-		return
+		return fmt.Errorf("total (%v) and success (%v) values are not numeric, this should never happen", tv, sv)
 	}
 
 	em.AddMetric("failure", metrics.NewInt(total.Int64()-success.Int64()))
+	return nil
 }
 
 // CumulativeToGauge creates a "gauge" EventMetrics from a "cumulative"

--- a/surfacers/common/transform/transform_test.go
+++ b/surfacers/common/transform/transform_test.go
@@ -1,0 +1,102 @@
+// Copyright 2017-2021 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transform
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/cloudprober/metrics"
+)
+
+func TestXxx(t *testing.T) {
+}
+
+func TestFailureCountForDefaultMetrics(t *testing.T) {
+	var tests = []struct {
+		total, success, failure metrics.Value
+		wantFailure             *metrics.Int
+		wantErr                 bool
+	}{
+		{
+			total:       metrics.NewInt(1000),
+			success:     metrics.NewInt(990),
+			wantFailure: metrics.NewInt(10),
+		},
+		{
+			total:       metrics.NewInt(1000),
+			success:     metrics.NewInt(990),
+			failure:     metrics.NewInt(20),
+			wantFailure: metrics.NewInt(20), // Not computed, original count.
+		},
+		{
+			total:       metrics.NewInt(1000),
+			success:     metrics.NewInt(1000),
+			wantFailure: metrics.NewInt(0),
+		},
+		{
+			success: metrics.NewInt(990),
+		},
+		{
+			total: metrics.NewInt(1000),
+		},
+		{
+			total:   metrics.NewInt(1000),
+			success: metrics.NewString("100"),
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%+v", test), func(t *testing.T) {
+			em := metrics.NewEventMetrics(time.Now()).
+				AddMetric("total", test.total).
+				AddMetric("success", test.success)
+
+			if test.failure != nil {
+				em.AddMetric("failure", test.failure)
+			}
+
+			if err := AddFailureMetric(em); err != nil {
+				if !test.wantErr {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if test.wantErr {
+				t.Errorf("didn't get expected error")
+			}
+
+			gotFailure := em.Metric("failure")
+
+			if test.wantFailure == nil {
+				if gotFailure != nil {
+					t.Errorf("Unexpected failure count metric (with value: %d)", gotFailure.(metrics.NumValue).Int64())
+				}
+				return
+			}
+
+			if test.wantFailure != nil && gotFailure == nil {
+				t.Errorf("Not creating failure count metric; expected metric with value: %d", test.wantFailure.Int64())
+				return
+			}
+
+			if gotFailure.(metrics.NumValue).Int64() != test.wantFailure.Int64() {
+				t.Errorf("Failure count=%v, want=%v", test.wantFailure.Int64(), test.wantFailure.Int64())
+			}
+		})
+	}
+}

--- a/surfacers/surfacers.go
+++ b/surfacers/surfacers.go
@@ -106,7 +106,9 @@ func (sw *surfacerWrapper) Write(ctx context.Context, em *metrics.EventMetrics) 
 	}
 
 	if sw.opts.AddFailureMetric {
-		transform.AddFailureMetric(em, sw.opts.Logger)
+		if err := transform.AddFailureMetric(em); err != nil {
+			sw.opts.Logger.Warning(err.Error())
+		}
 	}
 
 	if sw.opts.Config.GetExportAsGauge() && em.Kind == metrics.CUMULATIVE {


### PR DESCRIPTION
Now that we have a central way to add failure metric, remove individual implementations.

PiperOrigin-RevId: 377314575