### PR TITLE
Wait for targets in smaller steps before entering HTTP probe loop

### DIFF
--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -552,7 +552,7 @@ func (p *Probe) Start(ctx context.Context, dataChan chan *metrics.EventMetrics) 
 			break
 		}
 		p.updateTargetsAndStartProbes(ctx, dataChan)
-		time.Sleep(p.opts.Interval)
+		time.Sleep(time.Second)
 	}
 
 	targetsUpdateTicker := time.NewTicker(p.targetsUpdateInterval)


### PR DESCRIPTION
```
// Do more frequent listing of targets until we get a non-zero list of
// targets.

```

1 second should be more frequent than probe interval.

Addresses: https://github.com/google/cloudprober/issues/613
