### PR TITLE
Check for l.logger being nil before attempting to log remotely.

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -237,7 +237,7 @@ func (l *Logger) log(severity logging.Severity, payload ...string) {
 		return
 	}
 
-	if l.logc == nil {
+	if l.logger == nil {
 		genericLog(severity, l.name, payloadStr)
 		return
 	}


### PR DESCRIPTION
We currently check for l.logc being nil, but l.logger is better check, as it's possible that log client (l.logc) is not nil, but l.logger has not been initialized yet.

Ref: https://github.com/google/cloudprober/issues/616#issuecomment-879593718
PiperOrigin-RevId: 384639303