### PR TITLE
Fix metadata retrieval when running on GKE.

### DIFF
--- a/common/metadata/metadata.go
+++ b/common/metadata/metadata.go
@@ -1,0 +1,40 @@
+// Copyright 2021 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package metadata implements metadata related utilities.
+*/
+package metadata
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+// IsKubernetes return true if running on Kubernetes.
+// It uses the environment variable KUBERNETES_SERVICE_HOST to decide if we
+// we are running Kubernetes.
+func IsKubernetes() bool {
+	return os.Getenv("KUBERNETES_SERVICE_HOST") != ""
+}
+
+// KubernetesNamespace returns the Kubernetes namespace. It returns an empty
+// string if there is an error in retrieving the namespace.
+func KubernetesNamespace() string {
+	namespaceBytes, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err == nil {
+		return string(namespaceBytes)
+	}
+	return ""
+}


### PR DESCRIPTION
= Use KUBERNETES_SERVICE_HOST variable to decide if we are running on Kubernetes. This variable should always be set while running on Kubernetes.

= On GKE, metadata requests are handled by GKE metadata server which supports only a subset of the GCE metadata variables:
https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#gke_mds
While on GCE and Kubernetes, don't try to initialize other variables.

= For stackdriver metrics, use cluster-location instance attribute for resource "location", instead of instance zone. Fetching instance zone metadata may not work on GKE.

Ref: https://github.com/google/cloudprober/issues/616#issuecomment-879593718
PiperOrigin-RevId: 384765519