### PR TITLE
Make target's port available for labeling.

### DIFF
--- a/probes/dns/dns.go
+++ b/probes/dns/dns.go
@@ -113,7 +113,7 @@ func (p *Probe) updateTargets() {
 
 	for _, target := range p.targets {
 		for _, al := range p.opts.AdditionalLabels {
-			al.UpdateForTarget(target.Name, target.Labels)
+			al.UpdateForTarget(target)
 		}
 	}
 }

--- a/probes/external/external.go
+++ b/probes/external/external.go
@@ -598,7 +598,7 @@ func (p *Probe) updateTargets() {
 		}
 
 		for _, al := range p.opts.AdditionalLabels {
-			al.UpdateForTarget(target.Name, target.Labels)
+			al.UpdateForTarget(target)
 		}
 	}
 }

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -414,7 +414,7 @@ func (p *Probe) startForTarget(ctx context.Context, target endpoint.Endpoint, da
 	var runCnt int64
 
 	for _, al := range p.opts.AdditionalLabels {
-		al.UpdateForTarget(target.Name, target.Labels)
+		al.UpdateForTarget(target)
 	}
 	result := p.newResult()
 	req := p.httpRequestForTarget(target, nil)

--- a/probes/ping/ping.go
+++ b/probes/ping/ping.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 The Cloudprober Authors.
+// Copyright 2017-2021 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -195,7 +195,7 @@ func (p *Probe) updateTargets() {
 
 	for _, target := range p.targets {
 		for _, al := range p.opts.AdditionalLabels {
-			al.UpdateForTarget(target.Name, target.Labels)
+			al.UpdateForTarget(target)
 		}
 
 		// Update results map:

--- a/probes/udp/udp.go
+++ b/probes/udp/udp.go
@@ -452,7 +452,7 @@ func (p *Probe) updateTargets() {
 	}
 	for _, target := range p.targets {
 		for _, al := range p.opts.AdditionalLabels {
-			al.UpdateForTarget(target.Name, target.Labels)
+			al.UpdateForTarget(target)
 		}
 	}
 	p.initProbeRunResults()

--- a/probes/udplistener/udplistener.go
+++ b/probes/udplistener/udplistener.go
@@ -150,7 +150,7 @@ func (p *Probe) updateTargets() {
 
 	for _, target := range p.targets {
 		for _, al := range p.opts.AdditionalLabels {
-			al.UpdateForTarget(target.Name, target.Labels)
+			al.UpdateForTarget(target)
 		}
 	}
 }


### PR DESCRIPTION
Ref: https://github.com/google/cloudprober/issues/582
PiperOrigin-RevId: 386808079