### PR TITLE
Fix file provider test flakiness.

### DIFF
--- a/rds/file/file_test.go
+++ b/rds/file/file_test.go
@@ -233,8 +233,8 @@ func testModTimeCheckBehavior(t *testing.T, disableModTimeCheck bool) {
 	}
 	ls.refresh()
 
-	if !ls.lastUpdated.After(fileModTime) {
-		t.Errorf("File lister last update time (%v) not after file mod time (%v)", ls.lastUpdated, fileModTime)
+	if ls.lastUpdated.Before(fileModTime) {
+		t.Errorf("File lister last update time (%v) before file mod time (%v)", ls.lastUpdated, fileModTime)
 	}
 	res, err = ls.ListResources(nil)
 	if err != nil {


### PR DESCRIPTION
Instead of checking for lister time being after the file mod time, check for it not being before the file mod time.

File lister update time can be same as temp file's mod time. In some test environments, time.Now() may not change from one call to another.

Failure ref: https://github.com/google/cloudprober/runs/3196053886

PiperOrigin-RevId: 387668329