### PR TITLE
Increase MaxIdleConnsPerHost based on requests-per-probe parameter.

### DIFF
--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -200,6 +200,9 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 	} else {
 		// If it's been more than 2 probe intervals since connection was used, close it.
 		transport.IdleConnTimeout = 2 * p.opts.Interval
+		if p.c.GetRequestsPerProbe() > 1 {
+			transport.MaxIdleConnsPerHost = int(p.c.GetRequestsPerProbe())
+		}
 	}
 
 	if p.c.GetOauthConfig() != nil {


### PR DESCRIPTION
Without this option, keep-alive and parallel probing (multiple requests per probe) don't work very well together.

Note: Default MaxIdleConnsPerHost is 2.
PiperOrigin-RevId: 388287864