### PR TITLE
Update cloudprober ping MTU to 9001 to allow jumbo packets.

### DIFF
--- a/probes/ping/ping.go
+++ b/probes/ping/ping.go
@@ -63,7 +63,7 @@ const (
 	dataIntegrityKey = "data-integrity"
 	icmpHeaderSize   = 8
 	minPacketSize    = icmpHeaderSize + timeBytesSize // 16
-	maxPacketSize    = 5000                           // MTU
+	maxPacketSize    = 9001                           // MTU
 )
 
 type result struct {


### PR DESCRIPTION
PiperOrigin-RevId: 388596070