### PR TITLE
External probe: Send metrics even if requests timeout.

### DIFF
--- a/probes/external/external.go
+++ b/probes/external/external.go
@@ -527,6 +527,17 @@ func (p *Probe) runServerProbe(ctx, startCtx context.Context) {
 
 	// Wait for receiver goroutine to exit.
 	wg.Wait()
+
+	// Handle requests that we have not yet received replies for: "requests" will
+	// contain only outstanding requests by this point.
+	requestsMu.Lock()
+	defer requestsMu.Unlock()
+	for _, req := range requests {
+		p.processProbeResult(&probeStatus{
+			target:  req.target,
+			success: false,
+		}, p.results[req.target])
+	}
 }
 
 // runCommand encapsulates command executor in a variable so that we can


### PR DESCRIPTION
Also, add tests that would have caught this bug.

Ref: https://github.com/google/cloudprober/issues/653
PiperOrigin-RevId: 393020350