### PR TITLE
fixing the imports in the example

### DIFF
--- a/probes/external/serverutils/serverutils.go
+++ b/probes/external/serverutils/serverutils.go
@@ -104,8 +104,9 @@ func WriteMessage(pb proto.Message, w io.Writer) error {
 // provided mainly to help external probe server implementations. Cloudprober doesn't
 // make use of it. Example usage:
 //	import (
-//		serverpb "github.com/google/cloudprober/probes/external/serverutils/server_proto"
-//		"github.com/google/cloudprober/probes/external/serverutils/serverutils"
+//		serverpb "github.com/google/cloudprober/probes/external/proto"
+//    		"github.com/google/cloudprober/probes/external/serverutils"
+//		"google.golang.org/protobuf/proto"
 //	)
 //	func runProbe(opts []*cppb.ProbeRequest_Option) {
 //  	...


### PR DESCRIPTION
This PR just fixes a regression in a comment. The comment is just some code that outlines how to use serverutils to parse incoming messages in an EXTERNAL-Probe in order to implement SERVER-mode there. 
The current comment lists imports that are not longer valid and I simply replaced the import statements with the correct ones.

No change on any running code performed through this PR. It should be safe to merge.

But as always please review carefully and use on your own risk.